### PR TITLE
Procedure menu buttons

### DIFF
--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/AddEquipmentFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/AddEquipmentFragment.java
@@ -16,6 +16,7 @@ import android.widget.NumberPicker;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -90,6 +91,27 @@ public class AddEquipmentFragment extends Fragment {
 
         FirebaseAuth mAuth = FirebaseAuth.getInstance();
         String userId = Objects.requireNonNull(mAuth.getCurrentUser()).getUid();
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                ProcedureInfoFragment fragment = new ProcedureInfoFragment();
+                Bundle bundle = new Bundle();
+                bundle.putSerializable("procedure_info", procedureInfo);
+                fragment.setArguments(bundle);
+
+                FragmentManager fragmentManager = Objects.requireNonNull(getActivity()).getSupportFragmentManager();
+                //clears other fragments
+                fragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+                FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+                fragmentTransaction.setCustomAnimations(R.anim.enter_left, R.anim.fui_slide_out_left);
+                fragmentTransaction.add(R.id.activity_main, fragment);
+                fragmentTransaction.addToBackStack(null);
+                fragmentTransaction.commit();
+            }
+        };
+        requireActivity().getOnBackPressedDispatcher().addCallback(this, callback);
+
 
         final DocumentReference currentUserRef = usersRef.document(userId);
         currentUserRef.get().addOnCompleteListener(new OnCompleteListener<DocumentSnapshot>() {

--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ProcedureInfoFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ProcedureInfoFragment.java
@@ -127,7 +127,6 @@ public class ProcedureInfoFragment extends Fragment {
         if (getArguments() != null) {
             Bundle procedureInfoBundle = this.getArguments();
             if(procedureInfoBundle.get("procedure_info") != null){
-                checkAllFields = true;
                 HashMap<String, String> procedureEquipment = (HashMap<String, String>) procedureInfoBundle.getSerializable("procedure_info");
                 if(procedureEquipment != null) {
                     procedureDateEditText.setText(procedureEquipment.get("procedure_date"));
@@ -137,6 +136,8 @@ public class ProcedureInfoFragment extends Fragment {
                     roomTimeEditText.setText(procedureEquipment.get("room_time"));
                     fluoroTimeEditText.setText(procedureEquipment.get("fluoro_time"));
                     accessionNumberEditText.setText(procedureEquipment.get("accession_number"));
+                    checkAllFields = true;
+                    checkAutoComplete = validateAutoComplete(new AutoCompleteTextView[]{procedureNameEditText});
                 }
             }
         }

--- a/app/src/main/res/layout/fragment_addequipment.xml
+++ b/app/src/main/res/layout/fragment_addequipment.xml
@@ -27,7 +27,6 @@
             android:gravity="center"
             app:layout_scrollFlags="scroll|enterAlways|snap"
             app:liftOnScroll="true"
-            app:menu="@menu/fragment_navbar"
             app:navigationIcon="@drawable/icon_back"
             app:title="Equipments used"
             app:titleTextColor="@android:color/white" />


### PR DESCRIPTION
**Current Behaviour**
- Cancel and next buttons not working in the "Equipment Used"
- If the top right back button is clicked in "Equipment Used", the accession number needs to be created again to go to the next page
- If the android back button is clicked in "Equipment used", user is taken back to the home screen and not the previous page

#40 

**New Behaviour**
- Cancel and next buttons removed in menu
- Accession number doesn't need to be created again if already filled in
- Using the back button, takes user to the previous screen and not the home screen

**How to Test**

1. Create procedure
2. Enter details and hit next
3. Hit the back button in the top right
4. Hit next again
5. Hit the android back button