### PR TITLE
Fixing udis with + in front (issue #50) 

### DIFF
--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ItemDetailFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ItemDetailFragment.java
@@ -1259,67 +1259,12 @@ public class ItemDetailFragment extends Fragment {
         }
     }
 
-    // method for saving data to firebase cloud firestore
-    public void saveData(View view, String NETWORKS, String NETWORK, String SITES, String SITE,
-                         String DEPARTMENTS, String DEPARTMENT, String PRODUCTDIS) {
-
-        Log.d(TAG, "SAVING");
-
-
-        String udi_str = Objects.requireNonNull(udiEditText.getText()).toString();
-        String name_str = Objects.requireNonNull(nameEditText.getText()).toString();
-        String company_str = Objects.requireNonNull(company.getText()).toString();
-        String medical_speciality_str = Objects.requireNonNull(medicalSpeciality.getText()).toString();
-        String di_str = Objects.requireNonNull(deviceIdentifier.getText()).toString();
-        String description_str = Objects.requireNonNull(deviceDescription.getText()).toString();
-        String lotNumber_str = Objects.requireNonNull(lotNumber.getText()).toString();
-        String referenceNumber_str = Objects.requireNonNull(referenceNumber.getText()).toString();
-        String expiration_str = Objects.requireNonNull(expiration.getText()).toString();
-        String currentDate_str = Objects.requireNonNull(dateIn.getText()).toString();
-
-        String numberAddedStr = Objects.requireNonNull(numberAdded.getText()).toString();
-        int newTotalQuantity = Integer.parseInt(itemQuantity) +
-                Integer.parseInt(Objects.requireNonNull(numberAdded.getText()).toString());
-
-        //save the udi to include expiration date and lot number
-        if (isDi) {
-            String mmyy_str = (expiration_str.substring(5, 7) + expiration_str.substring(2, 4));
-            udi_str = udi_str + "$$" + mmyy_str + lotNumber_str;
-        }
-        final String barcode_str = udi_str;
-
-        diQuantity = String.valueOf(Integer.parseInt(diQuantity) +
-                Integer.parseInt(numberAdded.getText().toString()));
-
-
-        String quantityStr = String.valueOf(newTotalQuantity);
-        String site_name_str;
-        if (chosenSite) {
-            site_name_str = Objects.requireNonNull(otherSite_text.getText()).toString();
-        } else {
-            site_name_str = hospitalName.getText().toString();
-        }
-        String physical_location_str;
-        if (chosenLocation) {
-            physical_location_str = Objects.requireNonNull(otherPhysicalLoc_text.getText()).toString().trim();
-        } else {
-            physical_location_str = physicalLocation.getText().toString().trim();
-        }
-        String type_str;
-        if (chosenType) {
-            type_str = Objects.requireNonNull(otherType_text.getText()).toString();
-        } else {
-            type_str = equipmentType.getText().toString();
-        }
-        String currentTime_str = Objects.requireNonNull(timeIn.getText()).toString();
-        String notes_str = Objects.requireNonNull(notes.getText()).toString();
-
-
-        int radioButtonInt = useRadioGroup.getCheckedRadioButtonId();
-        RadioButton radioButton = view.findViewById(radioButtonInt);
-        String singleOrMultiUse = radioButton.getText().toString();
-
-
+    public void saveToDB(String name_str, String type_str, String company_str, String di_str, String site_name_str,
+                         String description_str, String medical_speciality_str, Object singleOrMultiUse, final String barcode_str,
+                         String numberAddedStr, String lotNumber_str, String expiration_str, String quantityStr, String currentTime_str,
+                         String physical_location_str, String referenceNumber_str, String notes_str, String currentDate_str,
+                         View view, String NETWORKS, String NETWORK, String SITES, String SITE, String DEPARTMENTS, String DEPARTMENT,
+                         String PRODUCTDIS) {
         // saving di-specific identifiers using HashMap
         Map<String, Object> diDoc = new HashMap<>();
         diDoc.put(NAME_KEY, name_str);
@@ -1426,6 +1371,113 @@ public class ItemDetailFragment extends Fragment {
                         }
                     });
         }
+
+
+    }
+
+    // method for saving data to firebase cloud firestore
+    public void saveData(final View view, final String NETWORKS, final String NETWORK, final String SITES, final String SITE,
+                         final String DEPARTMENTS, final String DEPARTMENT, final String PRODUCTDIS) {
+
+        Log.d(TAG, "SAVING");
+
+
+        final String name_str = Objects.requireNonNull(nameEditText.getText()).toString();
+        final String company_str = Objects.requireNonNull(company.getText()).toString();
+        final String medical_speciality_str = Objects.requireNonNull(medicalSpeciality.getText()).toString();
+        final String di_str = Objects.requireNonNull(deviceIdentifier.getText()).toString();
+        final String description_str = Objects.requireNonNull(deviceDescription.getText()).toString();
+        final String lotNumber_str = Objects.requireNonNull(lotNumber.getText()).toString();
+        final String referenceNumber_str = Objects.requireNonNull(referenceNumber.getText()).toString();
+        final String expiration_str = Objects.requireNonNull(expiration.getText()).toString();
+        final String currentDate_str = Objects.requireNonNull(dateIn.getText()).toString();
+        final String numberAddedStr = Objects.requireNonNull(numberAdded.getText()).toString();
+
+        diQuantity = String.valueOf(Integer.parseInt(diQuantity) +
+                Integer.parseInt(numberAdded.getText().toString()));
+
+
+        String site_name;
+        if (chosenSite) {
+             site_name = Objects.requireNonNull(otherSite_text.getText()).toString();
+        } else {
+             site_name = hospitalName.getText().toString();
+        }
+        final String site_name_str = site_name;
+
+        String physical_location;
+        if (chosenLocation) {
+            physical_location = Objects.requireNonNull(otherPhysicalLoc_text.getText()).toString().trim();
+        } else {
+            physical_location = physicalLocation.getText().toString().trim();
+        }
+        final String physical_location_str = physical_location;
+
+        String type;
+        if (chosenType) {
+            type = Objects.requireNonNull(otherType_text.getText()).toString();
+        } else {
+            type = equipmentType.getText().toString();
+        }
+        final String type_str = type;
+        final String currentTime_str = Objects.requireNonNull(timeIn.getText()).toString();
+        final String notes_str = Objects.requireNonNull(notes.getText()).toString();
+
+
+        int radioButtonInt = useRadioGroup.getCheckedRadioButtonId();
+        final RadioButton radioButton = view.findViewById(radioButtonInt);
+        final String singleOrMultiUse = radioButton.getText().toString();
+
+        if (!isDi) {
+            //regular barcodes
+            final String barcode_str = Objects.requireNonNull(udiEditText.getText()).toString();
+            int newTotalQuantity = Integer.parseInt(itemQuantity) +
+                    Integer.parseInt(Objects.requireNonNull(numberAdded.getText()).toString());
+            final String quantityStr = String.valueOf(newTotalQuantity);
+
+            saveToDB(name_str,type_str,company_str, di_str,site_name_str, description_str, medical_speciality_str,
+                    singleOrMultiUse, barcode_str, numberAddedStr, lotNumber_str, expiration_str, quantityStr,
+                    currentTime_str, physical_location_str, referenceNumber_str, notes_str, currentDate_str,
+                    view, NETWORKS, NETWORK, SITES, SITE, DEPARTMENTS, DEPARTMENT,PRODUCTDIS);
+
+        } else {
+            //hibcc barcodes: alter the udi string and check for quantity
+            String udi_str = Objects.requireNonNull(udiEditText.getText()).toString();
+            String mmyy_str = (expiration_str.substring(5, 7) + expiration_str.substring(2, 4));
+            udi_str = udi_str + "$$" + mmyy_str + lotNumber_str;
+            final String barcode_str = udi_str;
+
+            DocumentReference newUdiDoc = db.collection("networks").document(mNetworkId)
+                    .collection("hospitals").document(mHospitalId).collection("departments")
+                    .document("default_department").collection("dis").document(di)
+                    .collection("udis").document(barcode_str);
+
+            newUdiDoc.get().addOnCompleteListener(new OnCompleteListener<DocumentSnapshot>() {
+                @Override
+                public void onComplete(@NonNull Task<DocumentSnapshot> task) {
+                    if (task.isSuccessful()) {
+                        DocumentSnapshot document = task.getResult();
+                        if (Objects.requireNonNull(document).exists()) {
+                            if (document.get("quantity") != null) {
+                                itemQuantity = document.getString(QUANTITY_KEY);
+                            } else {
+                                itemQuantity = "0";
+                            }
+
+                        }
+                        int newTotalQuantity = Integer.parseInt(itemQuantity) +
+                                Integer.parseInt(Objects.requireNonNull(numberAdded.getText()).toString());
+                        final String quantityStr = String.valueOf(newTotalQuantity);
+                        saveToDB(name_str,type_str,company_str, di_str,site_name_str,
+                                description_str, medical_speciality_str, singleOrMultiUse, barcode_str, numberAddedStr, lotNumber_str,
+                                expiration_str, quantityStr, currentTime_str, physical_location_str, referenceNumber_str,
+                                notes_str, currentDate_str, view, NETWORKS, NETWORK, SITES, SITE, DEPARTMENTS, DEPARTMENT,PRODUCTDIS);
+                    }
+                }
+            });
+
+        }
+
     }
 
     private void saveEquipmentCost(DocumentReference udiRef, TextInputEditText costEditText, TextInputEditText numberAdded, TextInputEditText dateIn){

--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ItemDetailFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ItemDetailFragment.java
@@ -1282,8 +1282,11 @@ public class ItemDetailFragment extends Fragment {
                 Integer.parseInt(Objects.requireNonNull(numberAdded.getText()).toString());
 
         //save the udi to include expiration date and lot number
-        String mmyy_str = (expiration_str.substring(5,7) + expiration_str.substring(2,4));
-        final String barcode_str = udi_str + "$$" + mmyy_str + lotNumber_str;
+        if (isDi) {
+            String mmyy_str = (expiration_str.substring(5, 7) + expiration_str.substring(2, 4));
+            udi_str = udi_str + "$$" + mmyy_str + lotNumber_str;
+        }
+        final String barcode_str = udi_str;
 
         diQuantity = String.valueOf(Integer.parseInt(diQuantity) +
                 Integer.parseInt(numberAdded.getText().toString()));


### PR DESCRIPTION
**New behavior**
When a primary HIBCC barcode is entered as a udi, di level information is retrieved from the GUIDID database.  This is done by sending the primary barcode as a di with the first character (+) and last character removed. 

The user must then manually enter missing information (location, lot number, expiration date).

When saving to the database, the udi will be saved in the format: udi + $$ + expiration date MMYY + lot number.  

**To Test**
Enter a primary HIBCC barcode (one that starts with +), autopopulate, and save.  Attempt to save the same barcode twice with different expiration dates and make sure it saves twice with a unique udi. 

**NOTE:** the barcode +H965457561K will still crash the app due to issue #54




