### PR TITLE
[Refactor] Modified repository code to save procedure to new schema

### DIFF
--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/AddProcedureActivity.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/AddProcedureActivity.java
@@ -20,27 +20,28 @@ public class AddProcedureActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         ProcedureViewModel procedureViewModel = new ViewModelProvider(this).get(ProcedureViewModel.class);
         procedureViewModel.getCurrentStep().observe(this, this::setCurrentPage);
+        procedureViewModel.getUserLiveData().observe(this,userResource -> procedureViewModel.setupRepositories());
         setContentView(R.layout.activity_add_procedure);
     }
 
     private void setCurrentPage(Integer step) {
-        if (step == 1) {
-            // go to add equipment page
-            Fragment currentFragment = new AddEquipmentFragment();
-            FragmentManager fragmentManager = getSupportFragmentManager();
-            FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-            fragmentTransaction.add(R.id.add_procedure_frame_layout,currentFragment,AddEquipmentFragment.TAG);
-            fragmentTransaction.commit();
-        } else if (step == -1) {
-            // go back to main activity
-            finish();
-        } else {
+        if (step == 0){
             // go to add procedure details page
             Fragment currentFragment = new ProcedureInfoFragment();
             FragmentManager fragmentManager = getSupportFragmentManager();
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
             fragmentTransaction.add(R.id.add_procedure_frame_layout,currentFragment,ProcedureInfoFragment.TAG);
             fragmentTransaction.commit();
+        } else if (step == 1) {
+            // go to add equipment page
+            Fragment currentFragment = new AddEquipmentFragment();
+            FragmentManager fragmentManager = getSupportFragmentManager();
+            FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+            fragmentTransaction.add(R.id.add_procedure_frame_layout,currentFragment,AddEquipmentFragment.TAG);
+            fragmentTransaction.commit();
+        } else {
+            // go back to main activity
+            finish();
         }
 
 

--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/adapters/ProceduresAdapter.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/adapters/ProceduresAdapter.java
@@ -12,9 +12,11 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.getcarebase.carebase.R;
+import org.getcarebase.carebase.models.DeviceUsage;
 import org.getcarebase.carebase.models.Procedure;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public class ProceduresAdapter extends RecyclerView.Adapter<ProceduresAdapter.ViewHolder> {
@@ -49,9 +51,11 @@ public class ProceduresAdapter extends RecyclerView.Adapter<ProceduresAdapter.Vi
     }
 
     private final List<Procedure> procedures;
+    private final String uniqueDeviceIdentifier;
 
-    public ProceduresAdapter(List<Procedure> procedures) {
+    public ProceduresAdapter(List<Procedure> procedures, final String uniqueDeviceIdentifier) {
         this.procedures = procedures;
+        this.uniqueDeviceIdentifier = uniqueDeviceIdentifier;
     }
 
     @NonNull
@@ -79,7 +83,11 @@ public class ProceduresAdapter extends RecyclerView.Adapter<ProceduresAdapter.Vi
         holder.procedureDateView.setText(procedure.getDate());
         holder.accessionNumberView.setText(procedure.getAccessionNumber());
         holder.procedureNameView.setText(procedure.getName());
-        holder.amountUsedView.setText(holder.amountUsedView.getContext().getResources().getQuantityString(R.plurals.number_of_units,procedure.getAmountUsed(),procedure.getAmountUsed()));
+        Optional<DeviceUsage> usage = procedure.getDeviceUsages().stream().filter(deviceUsage -> deviceUsage.getUniqueDeviceIdentifier().equals(uniqueDeviceIdentifier)).findFirst();
+        if (usage.isPresent()) {
+            int amountUsed = usage.get().getAmountUsed();
+            holder.amountUsedView.setText(holder.amountUsedView.getContext().getResources().getQuantityString(R.plurals.number_of_units,amountUsed,amountUsed));
+        }
         holder.roomTimeInView.setText(procedure.getTimeIn());
         holder.roomTimeOutView.setText(procedure.getTimeOut());
         holder.roomTimeView.setText(procedure.getRoomTime());

--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ItemDetailViewFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ItemDetailViewFragment.java
@@ -192,7 +192,7 @@ import java.util.Objects;
                         addItemSpecs(specification.getKey(), specification.getValue().toString(), rootView);
                     }
 
-                    ProceduresAdapter proceduresAdapter = new ProceduresAdapter(deviceProduction.getProcedures());
+                    ProceduresAdapter proceduresAdapter = new ProceduresAdapter(deviceProduction.getProcedures(),deviceProduction.getUniqueDeviceIdentifier());
                     proceduresRecyclerView.setAdapter(proceduresAdapter);
                 }
                 else if (resourceData.getRequest().getStatus() == org.getcarebase.carebase.utils.Request.Status.ERROR){

--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ProcedureInfoFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ProcedureInfoFragment.java
@@ -73,7 +73,6 @@ public class ProcedureInfoFragment extends Fragment {
         Button continueButton = rootView.findViewById(R.id.procedure_continue_button);
 
         procedureViewModel = new ViewModelProvider(requireActivity()).get(ProcedureViewModel.class);
-        procedureViewModel.getUserLiveData().observe(getViewLifecycleOwner(),userResource -> procedureViewModel.setupDeviceRepository());
 
         topToolBar.setNavigationOnClickListener(view -> procedureViewModel.goToInventory());
 

--- a/app/src/main/java/org/getcarebase/carebase/models/DeviceUsage.java
+++ b/app/src/main/java/org/getcarebase/carebase/models/DeviceUsage.java
@@ -1,10 +1,18 @@
 package org.getcarebase.carebase.models;
 
+import com.google.firebase.firestore.Exclude;
+import com.google.firebase.firestore.PropertyName;
+
+/**
+ * represents the usage of a device in a medical procedure
+ */
 public class DeviceUsage {
-    private final String deviceIdentifier;
-    private final String uniqueDeviceIdentifier;
+    private String deviceIdentifier;
+    private String uniqueDeviceIdentifier;
     private int currentAmount;
     private int amountUsed;
+
+    public DeviceUsage() {}
 
     public DeviceUsage(String deviceIdentifier, String uniqueDeviceIdentifier, int currentAmount) {
         this.deviceIdentifier = deviceIdentifier;
@@ -28,19 +36,38 @@ public class DeviceUsage {
             throw new Error("The amount used of the device cannot be less than one");
     }
 
+    @Exclude
     public int getNewQuantity() {
         return Math.max(0, currentAmount - amountUsed);
     }
 
+    @PropertyName("amount_used")
     public int getAmountUsed() {
         return amountUsed;
     }
 
+    @PropertyName("amount_used")
+    public void setAmountUsed(int amountUsed) {
+        this.amountUsed = amountUsed;
+    }
+
+    @PropertyName("di")
     public String getDeviceIdentifier() {
         return deviceIdentifier;
     }
 
+    @PropertyName("di")
+    public void setDeviceIdentifier(String deviceIdentifier) {
+        this.deviceIdentifier = deviceIdentifier;
+    }
+
+    @PropertyName("udi")
     public String getUniqueDeviceIdentifier() {
         return uniqueDeviceIdentifier;
+    }
+
+    @PropertyName("udi")
+    public void setUniqueDeviceIdentifier(java.lang.String uniqueDeviceIdentifier) {
+        this.uniqueDeviceIdentifier = uniqueDeviceIdentifier;
     }
 }

--- a/app/src/main/java/org/getcarebase/carebase/models/Procedure.java
+++ b/app/src/main/java/org/getcarebase/carebase/models/Procedure.java
@@ -3,59 +3,23 @@ package org.getcarebase.carebase.models;
 import com.google.firebase.firestore.Exclude;
 import com.google.firebase.firestore.PropertyName;
 
+import java.util.List;
+
 /**
- * represents usage of a device
+ * represents a medical operation
  */
 public class Procedure {
-    private String deviceIdentifier;
-    private String uniqueDeviceIdentifier;
+    private String procedureId;
     private String accessionNumber;
-    private int amountUsed;
-    // TODO change device production quantity to type int instead of string in firebase
-    private String newQuantity;
     private String fluoroTime;
     private String date;
     private String name;
     private String roomTime;
     private String timeIn;
     private String timeOut;
+    private List<DeviceUsage> deviceUsages;
 
     public Procedure() {}
-
-    // helper constructor for procedure form
-    public Procedure(DeviceUsage deviceUsage, Procedure procedureDetails) {
-        this.deviceIdentifier = deviceUsage.getDeviceIdentifier();
-        this.uniqueDeviceIdentifier = deviceUsage.getUniqueDeviceIdentifier();
-        this.amountUsed = deviceUsage.getAmountUsed();
-        this.newQuantity = Integer.toString(deviceUsage.getNewQuantity());
-        this.accessionNumber = procedureDetails.getAccessionNumber();
-        this.fluoroTime = procedureDetails.getFluoroTime();
-        this.date = procedureDetails.getDate();
-        this.name = procedureDetails.getName();
-        this.roomTime = procedureDetails.getRoomTime();
-        this.timeIn = procedureDetails.getTimeIn();
-        this.timeOut = procedureDetails.getTimeOut();
-    }
-
-    @Exclude
-    public String getDeviceIdentifier() {
-        return deviceIdentifier;
-    }
-
-    @Exclude
-    public void setDeviceIdentifier(String deviceIdentifier) {
-        this.deviceIdentifier = deviceIdentifier;
-    }
-
-    @Exclude
-    public String getUniqueDeviceIdentifier() {
-        return uniqueDeviceIdentifier;
-    }
-
-    @Exclude
-    public void setUniqueDeviceIdentifier(String uniqueDeviceIdentifier) {
-        this.uniqueDeviceIdentifier = uniqueDeviceIdentifier;
-    }
 
     @PropertyName("accession_number")
     public String getAccessionNumber() {
@@ -65,21 +29,6 @@ public class Procedure {
     @PropertyName("accession_number")
     public void setAccessionNumber(String accessionNumber) {
         this.accessionNumber = accessionNumber;
-    }
-
-    @PropertyName("amount_used")
-    public int getAmountUsed() {
-        return amountUsed;
-    }
-
-    @PropertyName("amount_used")
-    public void setAmountUsed(int amountUsed) {
-        this.amountUsed = amountUsed;
-    }
-
-    @Exclude
-    public String getNewQuantity() {
-        return newQuantity;
     }
 
     @PropertyName("fluoro_time")
@@ -140,5 +89,15 @@ public class Procedure {
     @PropertyName("time_out")
     public void setTimeOut(String timeOut) {
         this.timeOut = timeOut;
+    }
+
+    @PropertyName("device_usages")
+    public List<DeviceUsage> getDeviceUsages() {
+        return deviceUsages;
+    }
+
+    @PropertyName("device_usages")
+    public void setDeviceUsages(List<DeviceUsage> deviceUsages) {
+        this.deviceUsages = deviceUsages;
     }
 }

--- a/app/src/main/java/org/getcarebase/carebase/repositories/ProcedureRepository.java
+++ b/app/src/main/java/org/getcarebase/carebase/repositories/ProcedureRepository.java
@@ -1,0 +1,99 @@
+package org.getcarebase.carebase.repositories;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+
+import org.getcarebase.carebase.R;
+import org.getcarebase.carebase.models.DeviceUsage;
+import org.getcarebase.carebase.models.Procedure;
+import org.getcarebase.carebase.utils.Request;
+import org.getcarebase.carebase.utils.Resource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This is class should handle all of the logic of saving and retrieving for procedures.
+ */
+public class ProcedureRepository {
+    private static final String TAG = ProcedureRepository.class.getName();
+    private final FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+
+    private final CollectionReference proceduresReference;
+    private final CollectionReference inventoryReference;
+
+    private List<Procedure> procedures;
+
+    public ProcedureRepository(final String networkId, final String hospitalId) {
+        inventoryReference = firestore.collection("networks").document(networkId)
+                .collection("hospitals").document(hospitalId)
+                .collection("departments").document("default_department")
+                .collection("dis");
+        proceduresReference = firestore.collection("networks").document(networkId)
+                .collection("hospitals").document(hospitalId)
+                .collection("departments").document("default_department")
+                .collection("procedures");
+        procedures = new ArrayList<>();
+    }
+
+    /**
+     * Saves the procedure information into every device used in the procedure
+     * @param procedure a representation of a medical procedure with a list of devices used in the
+     *                  procedure
+     * @return a Request object detailing the status of the request.
+     */
+    public LiveData<Request> saveProcedure(Procedure procedure) {
+        MutableLiveData<Request> saveProceduresRequest = new MutableLiveData<>();
+        List<Task<?>> tasks = new ArrayList<>();
+
+        Task<DocumentReference> procedureTask = proceduresReference.add(procedure);
+        // save dis and udis into an array to make procedure searchable
+        procedureTask.addOnSuccessListener(documentReference -> {
+            List<String> dis = procedure.getDeviceUsages().stream().map(DeviceUsage::getDeviceIdentifier).distinct().collect(Collectors.toList());
+            List<String> udis = procedure.getDeviceUsages().stream().map(DeviceUsage::getUniqueDeviceIdentifier).distinct().collect(Collectors.toList());
+            documentReference.update("dis", dis);
+            documentReference.update("udis", udis);
+        });
+        tasks.add(procedureTask);
+
+        for (DeviceUsage deviceUsage : procedure.getDeviceUsages()) {
+            // update devices quantities
+            DocumentReference deviceProductionReference = inventoryReference.document(deviceUsage.getDeviceIdentifier())
+                    .collection("udis").document(deviceUsage.getUniqueDeviceIdentifier());
+            tasks.add(deviceProductionReference.update("quantity",Integer.toString(deviceUsage.getNewQuantity())));
+        }
+
+        Tasks.whenAll(tasks).addOnCompleteListener(task -> {
+            if (task.isSuccessful()) {
+                saveProceduresRequest.setValue(new Request(null, Request.Status.SUCCESS));
+            } else {
+                // TODO make resource error string
+                saveProceduresRequest.setValue(new Request(R.string.error_something_wrong, Request.Status.ERROR));
+            }
+        });
+        return saveProceduresRequest;
+    }
+
+    public LiveData<Resource<List<Procedure>>> getProcedures() {
+        procedures.clear();
+        MutableLiveData<Resource<List<Procedure>>> proceduresLiveData = new MutableLiveData<>();
+        proceduresReference.get().addOnCompleteListener(task -> {
+           if (task.isSuccessful()) {
+               for (QueryDocumentSnapshot procedureSnapshot : task.getResult()) {
+                   procedures.add(procedureSnapshot.toObject(Procedure.class));
+               }
+           } else {
+               proceduresLiveData.setValue(new Resource<>(null,new Request(R.string.error_something_wrong,Request.Status.ERROR)));
+           }
+        });
+        return proceduresLiveData;
+    }
+}


### PR DESCRIPTION
This pull request changes the repository code to save and retrieve procedures from its new location in the schema. This new schema removes the redundancies in the same procedure details being saved to device used by making a new subcollection in the the department that holds all of the procedures. Bringing the procedure collection up allows for a much easier method to query all procedures.

### The Schema Before
<img width="374" alt="Screen Shot 2021-01-28 at 6 09 47 PM" src="https://user-images.githubusercontent.com/15002610/106210046-188ed500-6194-11eb-8de6-e50d05d5cceb.png">

### The Schema After

<img width="525" alt="Screen Shot 2021-01-28 at 6 09 58 PM" src="https://user-images.githubusercontent.com/15002610/106210055-1b89c580-6194-11eb-821d-5a925fa1fd75.png">


The procedures still have the same fields:
accession number, date, room time, time in, time out, fluoro time

However the procedure document also includes devices usages an array of device usage objects that have each the fields:
di, udi, and the amount used.

The procedure document also includes two arrays of unique strings containing the udis and dis of the devices used in the procedure so that the procedure can be searched when displaying the procedures that a certain device was used in.