### PR TITLE
Changed the DetailLabeledTextView layout for fields Date, Room Time, Time Start, Time End, Fluoro Time, and Accession Number.

### DIFF
--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ProcedureDetailFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ProcedureDetailFragment.java
@@ -36,8 +36,8 @@ public class ProcedureDetailFragment extends Fragment {
         View rootView = inflater.inflate(R.layout.procedure_detail_layout,container,false);
         MaterialToolbar toolbar = rootView.findViewById(R.id.toolbar);
         TextView nameView = rootView.findViewById(R.id.name_text_view);
-        TextView dateView = rootView.findViewById(R.id.date_text_view);
-        TextView timeView = rootView.findViewById(R.id.room_time_text_view);
+        DetailLabeledTextView dateView = rootView.findViewById(R.id.date_text_view);
+        DetailLabeledTextView timeView = rootView.findViewById(R.id.room_time_text_view);
         DetailLabeledTextView timeStartView = rootView.findViewById(R.id.time_start_text_view);
         DetailLabeledTextView timeEndView = rootView.findViewById(R.id.time_end_text_view);
         DetailLabeledTextView fluoroTimeView = rootView.findViewById(R.id.fluoro_time_text_view);
@@ -72,8 +72,8 @@ public class ProcedureDetailFragment extends Fragment {
             if (procedureResource.getRequest().getStatus() == Request.Status.SUCCESS) {
                 Procedure procedure = procedureResource.getData();
                 nameView.setText(procedure.getName());
-                dateView.setText(procedure.getDate());
-                timeView.setText(procedure.getRoomTime());
+                dateView.setTextValue(procedure.getDate());
+                timeView.setTextValue(procedure.getRoomTime());
                 timeStartView.setTextValue(procedure.getTimeIn());
                 timeEndView.setTextValue(procedure.getTimeOut());
                 fluoroTimeView.setTextValue(procedure.getFluoroTime());

--- a/app/src/main/res/layout/detail_text_view_layout.xml
+++ b/app/src/main/res/layout/detail_text_view_layout.xml
@@ -6,22 +6,19 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <TextView
-        android:id="@+id/value"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="8dp"
-        android:textAlignment="center"
-        android:background="@drawable/rounded_corners_background"
-        android:text="?attr/value_text"
-        tools:text="value" />
-
-    <TextView
         android:id="@+id/label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:textColor="@color/colorLightGrey"
         android:text="?attr/label_text"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
         tools:text="label"/>
+
+    <TextView
+        android:id="@+id/value"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="8dp"
+        android:text="?attr/value_text"
+        tools:text="value" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/procedure_detail_layout.xml
+++ b/app/src/main/res/layout/procedure_detail_layout.xml
@@ -51,44 +51,20 @@
             android:columnCount="2"
             android:rowCount="3"
             android:useDefaultMargins="true">
-
-            <LinearLayout
+            
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/date_text_view"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_columnWeight="1">
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/calendar"
-                    android:tint="@color/colorGrey" />
-                <TextView
-                    android:id="@+id/date_text_view"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:paddingLeft="8dp"
-                    android:lines="1"
-                    tools:text="2021/01/26"/>
-            </LinearLayout>
+                android:layout_columnWeight="1"
+                app:label_text="Date" />
 
-            <LinearLayout
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/room_time_text_view"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_columnWeight="1">
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/clock"
-                    android:tint="@color/colorGrey" />
-                <TextView
-                    android:id="@+id/room_time_text_view"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:paddingStart="8dp"
-                    android:lines="1"
-                    tools:text="70 Minutes"/>
-            </LinearLayout>
+                android:layout_columnWeight="1"
+                app:label_text="Time" />
 
             <org.getcarebase.carebase.views.DetailLabeledTextView
                 android:id="@+id/time_start_text_view"


### PR DESCRIPTION
Closes #78 
This pull requests changes the DetailLabeledTextView to be the style that have 
1) the label placed above the value
2) both label and value left-aligned
3) vertical padding as 8dp
4) the label appear with an overline text appearance
See example picture below.

**THE VIEW AFTER (see issue #78 for the view before)**

![detailLabeledTextView_after](https://user-images.githubusercontent.com/55464213/106671260-32595f00-657c-11eb-8c1d-53d55821c5a2.png)
