### PR TITLE
Appended " minutes" to the end of the value of fluoro time and room time when saving

### DIFF
--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ProcedureInfoFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ProcedureInfoFragment.java
@@ -186,6 +186,7 @@ public class ProcedureInfoFragment extends Fragment {
             String totalTime = (hours * 60 + mins) + "";
             roomTime.setText(totalTime);
         }catch(ParseException e){
+
             e.printStackTrace();
         }
     }
@@ -203,8 +204,8 @@ public class ProcedureInfoFragment extends Fragment {
         procedure.setDate(procedureDateEditText.getText().toString().trim());
         procedure.setTimeIn(timeInEditText.getText().toString().trim());
         procedure.setTimeOut(timeOutEditText.getText().toString().trim());
-        procedure.setRoomTime(roomTimeEditText.getText().toString().trim());
-        procedure.setFluoroTime(fluoroTimeEditText.getText().toString().trim());
+        procedure.setRoomTime(roomTimeEditText.getText().toString().trim() + " minutes");
+        procedure.setFluoroTime(fluoroTimeEditText.getText().toString().trim() + " minutes");
         procedure.setAccessionNumber(accessionNumberEditText.getText().toString().trim());
 
         procedureViewModel.setProcedureDetails(procedure);

--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ProcedureInfoFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ProcedureInfoFragment.java
@@ -186,7 +186,6 @@ public class ProcedureInfoFragment extends Fragment {
             String totalTime = (hours * 60 + mins) + "";
             roomTime.setText(totalTime);
         }catch(ParseException e){
-
             e.printStackTrace();
         }
     }

--- a/app/src/main/java/org/getcarebase/carebase/models/Procedure.java
+++ b/app/src/main/java/org/getcarebase/carebase/models/Procedure.java
@@ -48,9 +48,7 @@ public class Procedure {
     }
 
     @PropertyName("fluoro_time")
-    public void setFluoroTime(String fluoroTime) {
-        this.fluoroTime = fluoroTime;
-    }
+    public void setFluoroTime(String fluoroTime) { this.fluoroTime = fluoroTime + " minutes"; }
 
     @PropertyName("date")
     public String getDate() {
@@ -78,9 +76,7 @@ public class Procedure {
     }
 
     @PropertyName("room_time")
-    public void setRoomTime(String roomTime) {
-        this.roomTime = roomTime;
-    }
+    public void setRoomTime(String roomTime) { this.roomTime = roomTime; }
 
     @PropertyName("time_in")
     public String getTimeIn() {

--- a/app/src/main/java/org/getcarebase/carebase/models/Procedure.java
+++ b/app/src/main/java/org/getcarebase/carebase/models/Procedure.java
@@ -48,7 +48,7 @@ public class Procedure {
     }
 
     @PropertyName("fluoro_time")
-    public void setFluoroTime(String fluoroTime) { this.fluoroTime = fluoroTime + " minutes"; }
+    public void setFluoroTime(String fluoroTime) { this.fluoroTime = fluoroTime; }
 
     @PropertyName("date")
     public String getDate() {

--- a/app/src/main/res/layout/procedure_detail_layout.xml
+++ b/app/src/main/res/layout/procedure_detail_layout.xml
@@ -64,7 +64,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_columnWeight="1"
-                app:label_text="Time" />
+                app:label_text="Room Time" />
 
             <org.getcarebase.carebase.views.DetailLabeledTextView
                 android:id="@+id/time_start_text_view"


### PR DESCRIPTION
Closes #86

This pull request appended " minutes" to the end of the value of fluoro time and room time (" minutes" already exists following room time before I made any change) when saving.

**View After (Newly added procedure)**
![addMinutes](https://user-images.githubusercontent.com/55464213/106934561-415d2000-66e8-11eb-8065-896764c246b6.png)
