### PR TITLE
Repositioned and updated ItemDetailView fields

### DIFF
--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ItemDetailViewFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ItemDetailViewFragment.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -13,6 +14,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
@@ -32,6 +34,8 @@ import org.getcarebase.carebase.models.Cost;
 import org.getcarebase.carebase.models.DeviceModel;
 import org.getcarebase.carebase.models.DeviceProduction;
 import org.getcarebase.carebase.viewmodels.DeviceViewModel;
+import org.getcarebase.carebase.views.DetailLabeledTextView;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -42,56 +46,60 @@ public class ItemDetailViewFragment extends Fragment {
 
     private Activity parent;
 
-    private final FirebaseFirestore db = FirebaseFirestore.getInstance();
-
-    private String mNetworkId;
-    private String mHospitalId;
     private String itemQuantity;
     private String currentDate;
     private String currentTime;
     private DeviceViewModel deviceViewModel;
 
 
-//    private LinearLayout linearLayout;
-//    private LinearLayout itemSpecsLinearLayout;
-//    private LinearLayout costLayout;
-
-//    private ImageView specificationLayout;
-//    private ImageView costIcon;
     private TextView itemName;
     private TextView udi;
-    private TextView deviceIdentifier;
-    private TextView quantity;
-    private TextView expiration;
-    private TextView hospitalName;
-    private TextView physicalLocation;
-    private TextView type;
-    private TextView usage;
-    private TextView medicalSpecialty;
-    private TextView referenceNumber;
-    private TextView lotNumber;
-    private TextView manufacturer;
-    private TextView lastUpdate;
-//    private TextView notes;
-    private TextView deviceDescription;;
-//    private List<Map> costDoc;
-
-    private float dp;
+    private DetailLabeledTextView deviceIdentifier;
+    private DetailLabeledTextView quantity;
+    private DetailLabeledTextView expiration;
+    private DetailLabeledTextView physicalLocation;
+    private DetailLabeledTextView type;
+    private DetailLabeledTextView usage;
+    private DetailLabeledTextView medicalSpecialty;
+    private DetailLabeledTextView referenceNumber;
+    private DetailLabeledTextView lotNumber;
+    private DetailLabeledTextView manufacturer;
+    private DetailLabeledTextView lastUpdate;
+    private DetailLabeledTextView notes;
+    private DetailLabeledTextView deviceDescription;;
 
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        dp = requireContext().getResources().getDisplayMetrics().density;
         final View rootView = inflater.inflate(R.layout.fragment_viewonlyitemdetail, container, false);
         parent = getActivity();
         MaterialToolbar topToolBar = rootView.findViewById(R.id.topAppBar);
+        topToolBar.setOnMenuItemClickListener(item -> {
+            if (item.getItemId() == R.id.itemname_edit) {
+                ItemDetailFragment fragment = new ItemDetailFragment();
+                Bundle bundle = new Bundle();
+                bundle.putString("barcode", Objects.requireNonNull(udi.getText().toString()));
+                bundle.putBoolean("editingExisting", true);
+                bundle.putString("di", deviceIdentifier.getTextValue().toString());
+                fragment.setArguments(bundle);
+
+                FragmentManager fragmentManager = requireActivity().getSupportFragmentManager();
+                FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+                fragmentTransaction.setCustomAnimations(R.anim.fui_slide_in_right, R.anim.fui_slide_out_left);
+                fragmentTransaction.add(R.id.activity_main, fragment);
+                fragmentTransaction.addToBackStack(null);
+                fragmentTransaction.commit();
+                return true;
+            }
+            return false;
+        });
+
         itemName = rootView.findViewById(R.id.itemname_text);
-//        udi = rootView.findViewById(R.id.barcode_edittext);
+        udi = rootView.findViewById(R.id.udi_edittext);
         deviceIdentifier = rootView.findViewById(R.id.di_edittext);
         quantity = rootView.findViewById(R.id.quantity_edittext);
         expiration = rootView.findViewById(R.id.expiration_edittext);
-//        hospitalName = rootView.findViewById(R.id.site_edittext);
         physicalLocation = rootView.findViewById(R.id.physicallocation_edittext);
         type = rootView.findViewById(R.id.type_edittext);
         usage = rootView.findViewById(R.id.usage_edittext);
@@ -100,37 +108,7 @@ public class ItemDetailViewFragment extends Fragment {
         lotNumber = rootView.findViewById(R.id.lotnumber_edittext);
         manufacturer = rootView.findViewById(R.id.company_edittext);
         lastUpdate = rootView.findViewById(R.id.lasteupdate_edittext);
-//        notes = rootView.findViewById(R.id.notes_edittext);
         deviceDescription = rootView.findViewById(R.id.devicedescription_edittext);
-//        specificationLayout = rootView.findViewById(R.id.specifications_plus);
-//        linearLayout = rootView.findViewById(R.id.itemdetailviewonly_linearlayout);
-//        LinearLayout specsLinearLayout = rootView.findViewById(R.id.specs_linearlayout);
-//        itemSpecsLinearLayout = new LinearLayout(rootView.getContext());
-//        itemSpecsLinearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-//                ViewGroup.LayoutParams.WRAP_CONTENT));
-//        itemSpecsLinearLayout.setOrientation(LinearLayout.VERTICAL);
-//        itemSpecsLinearLayout.setVisibility(View.GONE);
-//        linearLayout.addView(itemSpecsLinearLayout, linearLayout.indexOfChild(specsLinearLayout) + 1);
-//        costDoc = new ArrayList<>();
-//        costLayout = rootView.findViewById(R.id.cost_linearlayout);
-//        costIcon = rootView.findViewById(R.id.cost_plus);
-//        ImageView itemNameEdit = rootView.findViewById(R.id.itemname_edit);
-
-//        LinearLayout proceduresDropdown = rootView.findViewById(R.id.procedures_dropdown);
-//        RecyclerView proceduresRecyclerView = rootView.findViewById(R.id.procedures_recycler_view);
-//        proceduresRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
-//        proceduresRecyclerView.addItemDecoration(new DividerItemDecoration(getContext(),
-//                DividerItemDecoration.VERTICAL));
-//        ImageView procedureToggleButton = rootView.findViewById(R.id.procedures_toggle_button);
-//        proceduresDropdown.setOnClickListener(view -> {
-//            if (proceduresRecyclerView.getVisibility() == View.VISIBLE) {
-//                proceduresRecyclerView.setVisibility(View.GONE);
-//                procedureToggleButton.setImageResource(R.drawable.ic_baseline_plus);
-//            } else {
-//                proceduresRecyclerView.setVisibility(View.VISIBLE);
-//                procedureToggleButton.setImageResource(R.drawable.icon_minimize);
-//            }
-//        });
 
 
         deviceViewModel = new ViewModelProvider(this).get(DeviceViewModel.class);
@@ -146,36 +124,25 @@ public class ItemDetailViewFragment extends Fragment {
                 if (resourceData.getRequest().getStatus() == org.getcarebase.carebase.utils.Request.Status.SUCCESS) {
                     DeviceModel deviceModel = resourceData.getData();
 
-                    type.setText(deviceModel.getEquipmentType());
-                    hospitalName.setText(deviceModel.getSiteName());
+                    type.setTextValue(deviceModel.getEquipmentType());
                     String usageStr = deviceModel.getUsage();
-                    usage.setText(usageStr);
-                    deviceDescription.setText(deviceModel.getDescription());
-                    deviceIdentifier.setText(deviceModel.getDeviceIdentifier());
-                    medicalSpecialty.setText(deviceModel.getMedicalSpecialty());
+                    usage.setTextValue(usageStr);
+                    deviceDescription.setTextValue(deviceModel.getDescription());
+                    deviceIdentifier.setTextValue(deviceModel.getDeviceIdentifier());
+                    medicalSpecialty.setTextValue(deviceModel.getMedicalSpecialty());
                     itemName.setText(deviceModel.getName());
-                    manufacturer.setText(deviceModel.getCompany());
+                    manufacturer.setTextValue(deviceModel.getCompany());
 
                     DeviceProduction deviceProduction = deviceModel.getProductions().get(0);
-                    expiration.setText(deviceProduction.getExpirationDate());
-                    lotNumber.setText(deviceProduction.getLotNumber());
-//                    notes.setText(deviceProduction.getNotes());
-                    physicalLocation.setText(deviceProduction.getPhysicalLocation());
+                    expiration.setTextValue(deviceProduction.getExpirationDate());
+                    lotNumber.setTextValue(deviceProduction.getLotNumber());
+                    physicalLocation.setTextValue(deviceProduction.getPhysicalLocation());
                     itemQuantity = deviceProduction.getStringQuantity();
-                    quantity.setText(itemQuantity);
+                    quantity.setTextValue(itemQuantity);
                     currentDate = deviceProduction.getDateAdded();
                     currentTime = deviceProduction.getTimeAdded();
-                    lastUpdate.setText(String.format("%s\n%s", currentDate, currentTime));
-                    referenceNumber.setText(deviceProduction.getReferenceNumber());
-
-//                    addCostInfo(deviceProduction.getCosts(), rootView);
-//
-//                    for (Map.Entry<String, Object> specification : deviceModel.getSpecificationList()) {
-//                        addItemSpecs(specification.getKey(), specification.getValue().toString(), rootView);
-//                    }
-//
-                    DeviceProceduresAdapter deviceProceduresAdapter = new DeviceProceduresAdapter(deviceProduction.getProcedures(),deviceProduction.getUniqueDeviceIdentifier());
-                    proceduresRecyclerView.setAdapter(deviceProceduresAdapter);
+                    lastUpdate.setTextValue(String.format("%s\n%s", currentDate, currentTime));
+                    referenceNumber.setTextValue(deviceProduction.getReferenceNumber());
                 }
                 else if (resourceData.getRequest().getStatus() == org.getcarebase.carebase.utils.Request.Status.ERROR){
                     Toast.makeText(parent.getApplicationContext(), resourceData.getRequest().getResourceString(), Toast.LENGTH_SHORT).show();
@@ -188,302 +155,7 @@ public class ItemDetailViewFragment extends Fragment {
                 parent.onBackPressed();
         });
 
-
-
-//        final boolean[] isSpecsMaximized = {false};
-//        specificationLayout.setOnClickListener(new View.OnClickListener() {
-//            @Override
-//            public void onClick(View view) {
-//                if (isSpecsMaximized[0]) {
-//                    isSpecsMaximized[0] = false;
-//                    itemSpecsLinearLayout.setVisibility(View.GONE);
-//                    specificationLayout.setImageResource(R.drawable.ic_baseline_plus);
-//
-//                } else {
-//                    itemSpecsLinearLayout.setVisibility(View.VISIBLE);
-//                    specificationLayout.setImageResource(R.drawable.icon_minimize);
-//                    isSpecsMaximized[0] = true;
-//
-//                }
-//            }
-//        });
-
-//        itemNameEdit.setOnClickListener(new View.OnClickListener() {
-//            @Override
-//            public void onClick(View view) {
-//                ItemDetailFragment fragment = new ItemDetailFragment();
-//                Bundle bundle = new Bundle();
-//                bundle.putString("barcode", Objects.requireNonNull(udi.getText()).toString());
-//                bundle.putBoolean("editingExisting", true);
-//                bundle.putString("di", deviceIdentifier.getText().toString());
-//                fragment.setArguments(bundle);
-//
-//                FragmentManager fragmentManager = requireActivity().getSupportFragmentManager();
-////            //clears other fragments
-//                FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-//                fragmentTransaction.setCustomAnimations(R.anim.fui_slide_in_right, R.anim.fui_slide_out_left);
-//                fragmentTransaction.add(R.id.activity_main, fragment);
-//                fragmentTransaction.addToBackStack(null);
-//                fragmentTransaction.commit();
-//            }
-//        });
-
-
-
         return rootView;
     }
-
-//    private void addItemSpecs(String key, String value, View view) {
-//
-//        LinearLayout eachItemSpecsLayout = new LinearLayout(view.getContext());
-//        eachItemSpecsLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-//                ViewGroup.LayoutParams.WRAP_CONTENT));
-//        eachItemSpecsLayout.setOrientation(LinearLayout.HORIZONTAL);
-//        eachItemSpecsLayout.setBackgroundColor(Color.WHITE);
-//
-//        LinearLayout.LayoutParams itemSpecsParams = new LinearLayout.LayoutParams(0,
-//                LinearLayout.LayoutParams.MATCH_PARENT);
-//        itemSpecsParams.weight = (float) 1.0;
-//        itemSpecsParams.setMargins(0, (int) (1 * dp), 0, (int) (1 * dp));
-//
-//
-//        TextView headerKey = new TextView(view.getContext());
-//        headerKey.setLayoutParams(itemSpecsParams);
-//        headerKey.setPadding((int) (8 * dp), (int) (8 * dp), (int) (8 * dp), (int) (8 * dp));
-//        headerKey.setText(key);
-//        headerKey.setFocusable(false);
-//        headerKey.setTypeface(headerKey.getTypeface(), Typeface.BOLD);
-//        headerKey.setTextSize(14);
-//        headerKey.setTextColor(Color.BLACK);
-//
-//
-//        LinearLayout.LayoutParams specValueParams = new LinearLayout.LayoutParams(0,
-//                LinearLayout.LayoutParams.MATCH_PARENT);
-//        specValueParams.weight = (float) 1.0;
-//        specValueParams.setMargins(0, (int) (1 * dp), 0, (int) (1 * dp));
-//
-//        TextView specsValue = new TextView(view.getContext());
-//        specsValue.setLayoutParams(specValueParams);
-//        specsValue.setPadding((int) (8 * dp), (int) (8 * dp), (int) (8 * dp), (int) (8 * dp));
-//        specsValue.setText(value);
-//        specsValue.setTextSize(14);
-//        specsValue.setTextColor(Color.BLACK);
-//
-//        eachItemSpecsLayout.addView(headerKey);
-//        eachItemSpecsLayout.addView(specsValue);
-//
-//        itemSpecsLinearLayout.addView(eachItemSpecsLayout);
-//    }
-
-
-//    private void addCostInfo(List<Cost> costs,View view){
-//        if(costs.size() > 0) {
-//            int i;
-//            final LinearLayout costInfoLayout = new LinearLayout(view.getContext());
-//            costInfoLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-//                    ViewGroup.LayoutParams.WRAP_CONTENT));
-//            costInfoLayout.setOrientation(LinearLayout.VERTICAL);
-//            costInfoLayout.setVisibility(View.GONE);
-//
-//            for (i = 0; i < costs.size(); i++) {
-//
-//                final LinearLayout eachEquipmentLayout = new LinearLayout(view.getContext());
-//                eachEquipmentLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-//                        ViewGroup.LayoutParams.WRAP_CONTENT));
-//                eachEquipmentLayout.setOrientation(LinearLayout.HORIZONTAL);
-//                eachEquipmentLayout.setBaselineAligned(false);
-//
-//                final TextInputLayout costDateHeader = new TextInputLayout(view.getContext());
-//                LinearLayout.LayoutParams costHeaderParams = new LinearLayout.LayoutParams(
-//                        LinearLayout.LayoutParams.MATCH_PARENT,
-//                        LinearLayout.LayoutParams.WRAP_CONTENT);
-//                costHeaderParams.weight = (float) 1.0;
-//                costDateHeader.setLayoutParams(costHeaderParams);
-//                TextInputEditText dateKey = new TextInputEditText(costDateHeader.getContext());
-//                dateKey.setBackgroundColor(Color.WHITE);
-//                dateKey.setText(R.string.purchaseDate_lbl);
-//                dateKey.setTypeface(dateKey.getTypeface(), Typeface.BOLD);
-//                dateKey.setFocusable(false);
-//                costDateHeader.addView(dateKey);
-//
-//
-//                final TextInputLayout costDateText = new TextInputLayout(view.getContext());
-//                LinearLayout.LayoutParams costParams = new LinearLayout.LayoutParams(
-//                        LinearLayout.LayoutParams.MATCH_PARENT,
-//                        LinearLayout.LayoutParams.WRAP_CONTENT);
-//                costParams.weight = (float) 1.0;
-//                costDateText.setLayoutParams(costParams);
-//                TextInputEditText dateText = new TextInputEditText(costDateText.getContext());
-//                dateText.setText(costs.get(i).getCostDate());
-//                dateText.setBackgroundColor(Color.WHITE);
-//                dateText.setFocusable(false);
-//                costDateText.addView(dateText);
-//                costDateText.setEndIconMode(TextInputLayout.END_ICON_CUSTOM);
-//                costDateText.setEndIconDrawable(R.drawable.ic_baseline_plus);
-//                costDateText.setEndIconTintList(ColorStateList.valueOf(getResources().
-//                        getColor(R.color.colorPrimary, requireActivity().getTheme())));
-//
-//                eachEquipmentLayout.addView(costDateHeader);
-//                eachEquipmentLayout.addView(costDateText);
-//                costInfoLayout.addView(eachEquipmentLayout);
-//
-//
-//                final LinearLayout costInfoDetails = new LinearLayout(view.getContext());
-//                costInfoDetails.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-//                        ViewGroup.LayoutParams.WRAP_CONTENT));
-//                costInfoDetails.setOrientation(LinearLayout.VERTICAL);
-//                costInfoDetails.setVisibility(View.GONE);
-//
-//                final LinearLayout packagePriceLinearLayout = new LinearLayout(view.getContext());
-//                packagePriceLinearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-//                        ViewGroup.LayoutParams.WRAP_CONTENT));
-//                packagePriceLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
-//                packagePriceLinearLayout.setBaselineAligned(false);
-//
-//                final TextInputLayout packagePriceHeader = new TextInputLayout(view.getContext());
-//                LinearLayout.LayoutParams packageHeaderParams = new LinearLayout.LayoutParams(
-//                        LinearLayout.LayoutParams.MATCH_PARENT,
-//                        LinearLayout.LayoutParams.WRAP_CONTENT);
-//                packageHeaderParams.weight = (float) 1.0;
-//                packagePriceHeader.setLayoutParams(packageHeaderParams);
-//                TextInputEditText packageKey = new TextInputEditText(packagePriceHeader.getContext());
-//                packageKey.setBackgroundColor(Color.WHITE);
-//                packageKey.setText(R.string.packageCost_lbl);
-//                packageKey.setTypeface(packageKey.getTypeface(), Typeface.BOLD);
-//                packageKey.setFocusable(false);
-//                packagePriceHeader.addView(packageKey);
-//
-//                final TextInputLayout packagePriceText = new TextInputLayout(view.getContext());
-//                LinearLayout.LayoutParams packageParams = new LinearLayout.LayoutParams(
-//                        LinearLayout.LayoutParams.MATCH_PARENT,
-//                        LinearLayout.LayoutParams.WRAP_CONTENT);
-//                packageParams.weight = (float) 1.0;
-//                packagePriceText.setLayoutParams(packageParams);
-//                TextInputEditText packagePriceEditText = new TextInputEditText(packagePriceText.getContext());
-//                packagePriceEditText.setText(String.format("$ %s", costs.get(i).getPackagePrice()));
-//                packagePriceEditText.setBackgroundColor(Color.WHITE);
-//                packagePriceEditText.setFocusable(false);
-//                packagePriceText.addView(packagePriceEditText);
-//
-//                packagePriceLinearLayout.addView(packagePriceHeader);
-//                packagePriceLinearLayout.addView(packagePriceText);
-//
-//                final LinearLayout numberAddedLinearLayout = new LinearLayout(view.getContext());
-//                numberAddedLinearLayout .setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-//                        ViewGroup.LayoutParams.WRAP_CONTENT));
-//                numberAddedLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
-//                numberAddedLinearLayout.setBaselineAligned(false);
-//
-//
-//                final TextInputLayout numberAddedHeader = new TextInputLayout(view.getContext());
-//                LinearLayout.LayoutParams numberAddedHeaderParams = new LinearLayout.LayoutParams(
-//                        LinearLayout.LayoutParams.MATCH_PARENT,
-//                        LinearLayout.LayoutParams.WRAP_CONTENT);
-//                numberAddedHeaderParams.weight = (float) 1.0;
-//                numberAddedHeader.setLayoutParams(numberAddedHeaderParams);
-//                TextInputEditText numberAddedKey = new TextInputEditText(numberAddedHeader.getContext());
-//                numberAddedKey.setBackgroundColor(Color.WHITE);
-//                numberAddedKey.setText(R.string.units_lbl);
-//                numberAddedKey.setTypeface(numberAddedKey.getTypeface(), Typeface.BOLD);
-//                numberAddedKey.setFocusable(false);
-//                numberAddedHeader.addView(numberAddedKey);
-//
-//                final TextInputLayout numberAddedText = new TextInputLayout(view.getContext());
-//                LinearLayout.LayoutParams numberAddedParams = new LinearLayout.LayoutParams(
-//                        LinearLayout.LayoutParams.MATCH_PARENT,
-//                        LinearLayout.LayoutParams.WRAP_CONTENT);
-//                numberAddedParams.weight = (float) 1.0;
-//                numberAddedText.setLayoutParams(numberAddedParams);
-//                TextInputEditText numberAddedEditText = new TextInputEditText(numberAddedText.getContext());
-//                numberAddedEditText.setText(Integer.toString(costs.get(i).getNumberAdded()));
-//                numberAddedEditText.setBackgroundColor(Color.WHITE);
-//                numberAddedEditText.setFocusable(false);
-//                numberAddedText.addView(numberAddedEditText);
-//
-//                numberAddedLinearLayout.addView(numberAddedHeader);
-//                numberAddedLinearLayout.addView(numberAddedText);
-//
-//                final LinearLayout unitCostLinearLayout = new LinearLayout(view.getContext());
-//                unitCostLinearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-//                        ViewGroup.LayoutParams.WRAP_CONTENT));
-//                unitCostLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
-//                unitCostLinearLayout.setBaselineAligned(false);
-//
-//
-//                final TextInputLayout unitCostHeader = new TextInputLayout(view.getContext());
-//                LinearLayout.LayoutParams unitCostParams = new LinearLayout.LayoutParams(
-//                        LinearLayout.LayoutParams.MATCH_PARENT,
-//                        LinearLayout.LayoutParams.WRAP_CONTENT);
-//                unitCostParams.weight = (float) 1.0;
-//                unitCostHeader.setLayoutParams(unitCostParams);
-//                TextInputEditText unitCostKey = new TextInputEditText(unitCostHeader.getContext());
-//                unitCostKey.setBackgroundColor(Color.WHITE);
-//                unitCostKey.setText(R.string.costUnit_lbl);
-//                unitCostKey.setTypeface(dateKey.getTypeface(), Typeface.BOLD);
-//                unitCostKey.setFocusable(false);
-//                unitCostHeader.addView(unitCostKey);
-//
-//                final TextInputLayout unitCostText = new TextInputLayout(view.getContext());
-//                LinearLayout.LayoutParams unitCostTextParams = new LinearLayout.LayoutParams(
-//                        LinearLayout.LayoutParams.MATCH_PARENT,
-//                        LinearLayout.LayoutParams.WRAP_CONTENT);
-//                unitCostTextParams.weight = (float) 1.0;
-//                unitCostText.setLayoutParams(unitCostTextParams);
-//                TextInputEditText unitCostEditText = new TextInputEditText(unitCostText.getContext());
-//                unitCostEditText.setText(String.format("$ %s", costs.get(i).getUnitPrice()));
-//                unitCostEditText.setBackgroundColor(Color.WHITE);
-//                unitCostEditText.setFocusable(false);
-//                unitCostText.addView(unitCostEditText);
-//
-//                unitCostLinearLayout.addView(unitCostHeader);
-//                unitCostLinearLayout.addView(unitCostText);
-//
-//                costInfoDetails.addView(packagePriceLinearLayout);
-//                costInfoDetails.addView(numberAddedLinearLayout);
-//                costInfoDetails.addView(unitCostLinearLayout);
-//
-//                costInfoLayout.addView(costInfoDetails);
-//
-//
-//
-//                final boolean[] isDetailMaximized = {false};
-//                costDateText.setEndIconOnClickListener(new View.OnClickListener() {
-//                    @Override
-//                    public void onClick(View view) {
-//                        if(isDetailMaximized[0]){
-//                            costInfoDetails.setVisibility(View.GONE);
-//                            isDetailMaximized[0] = false;
-//                            costDateText.setEndIconDrawable(R.drawable.ic_baseline_plus);
-//
-//                        }else{
-//                            costInfoDetails.setVisibility(View.VISIBLE);
-//                            isDetailMaximized[0] = true;
-//                            costDateText.setEndIconDrawable(R.drawable.icon_minimize);
-//                        }
-//                    }
-//                });
-//
-//            }
-//            linearLayout.addView(costInfoLayout, linearLayout.indexOfChild(costLayout) + 1);
-//
-//
-//            final boolean[] isMaximized = {false};
-//            costIcon.setOnClickListener(new View.OnClickListener() {
-//                @Override
-//                public void onClick(View view) {
-//                    if(isMaximized[0]){
-//                        costInfoLayout.setVisibility(View.GONE);
-//                        isMaximized[0] = false;
-//                        costIcon.setImageResource(R.drawable.ic_baseline_plus);
-//
-//                    }else{
-//                        costInfoLayout.setVisibility(View.VISIBLE);
-//                        isMaximized[0] = true;
-//                        costIcon.setImageResource(R.drawable.icon_minimize);
-//                    }
-//                }
-//            });
-//        }
-//    }
 
 }

--- a/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ItemDetailViewFragment.java
+++ b/app/src/main/java/org/getcarebase/carebase/activities/Main/fragments/ItemDetailViewFragment.java
@@ -52,12 +52,12 @@ public class ItemDetailViewFragment extends Fragment {
     private DeviceViewModel deviceViewModel;
 
 
-    private LinearLayout linearLayout;
-    private LinearLayout itemSpecsLinearLayout;
-    private LinearLayout costLayout;
+//    private LinearLayout linearLayout;
+//    private LinearLayout itemSpecsLinearLayout;
+//    private LinearLayout costLayout;
 
-    private ImageView specificationLayout;
-    private ImageView costIcon;
+//    private ImageView specificationLayout;
+//    private ImageView costIcon;
     private TextView itemName;
     private TextView udi;
     private TextView deviceIdentifier;
@@ -72,9 +72,9 @@ public class ItemDetailViewFragment extends Fragment {
     private TextView lotNumber;
     private TextView manufacturer;
     private TextView lastUpdate;
-    private TextView notes;
+//    private TextView notes;
     private TextView deviceDescription;;
-    private List<Map> costDoc;
+//    private List<Map> costDoc;
 
     private float dp;
 
@@ -87,11 +87,11 @@ public class ItemDetailViewFragment extends Fragment {
         parent = getActivity();
         MaterialToolbar topToolBar = rootView.findViewById(R.id.topAppBar);
         itemName = rootView.findViewById(R.id.itemname_text);
-        udi = rootView.findViewById(R.id.barcode_edittext);
+//        udi = rootView.findViewById(R.id.barcode_edittext);
         deviceIdentifier = rootView.findViewById(R.id.di_edittext);
         quantity = rootView.findViewById(R.id.quantity_edittext);
         expiration = rootView.findViewById(R.id.expiration_edittext);
-        hospitalName = rootView.findViewById(R.id.site_edittext);
+//        hospitalName = rootView.findViewById(R.id.site_edittext);
         physicalLocation = rootView.findViewById(R.id.physicallocation_edittext);
         type = rootView.findViewById(R.id.type_edittext);
         usage = rootView.findViewById(R.id.usage_edittext);
@@ -100,37 +100,37 @@ public class ItemDetailViewFragment extends Fragment {
         lotNumber = rootView.findViewById(R.id.lotnumber_edittext);
         manufacturer = rootView.findViewById(R.id.company_edittext);
         lastUpdate = rootView.findViewById(R.id.lasteupdate_edittext);
-        notes = rootView.findViewById(R.id.notes_edittext);
+//        notes = rootView.findViewById(R.id.notes_edittext);
         deviceDescription = rootView.findViewById(R.id.devicedescription_edittext);
-        specificationLayout = rootView.findViewById(R.id.specifications_plus);
-        linearLayout = rootView.findViewById(R.id.itemdetailviewonly_linearlayout);
-        LinearLayout specsLinearLayout = rootView.findViewById(R.id.specs_linearlayout);
-        itemSpecsLinearLayout = new LinearLayout(rootView.getContext());
-        itemSpecsLinearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT));
-        itemSpecsLinearLayout.setOrientation(LinearLayout.VERTICAL);
-        itemSpecsLinearLayout.setVisibility(View.GONE);
-        linearLayout.addView(itemSpecsLinearLayout, linearLayout.indexOfChild(specsLinearLayout) + 1);
-        costDoc = new ArrayList<>();
-        costLayout = rootView.findViewById(R.id.cost_linearlayout);
-        costIcon = rootView.findViewById(R.id.cost_plus);
-        ImageView itemNameEdit = rootView.findViewById(R.id.itemname_edit);
+//        specificationLayout = rootView.findViewById(R.id.specifications_plus);
+//        linearLayout = rootView.findViewById(R.id.itemdetailviewonly_linearlayout);
+//        LinearLayout specsLinearLayout = rootView.findViewById(R.id.specs_linearlayout);
+//        itemSpecsLinearLayout = new LinearLayout(rootView.getContext());
+//        itemSpecsLinearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+//                ViewGroup.LayoutParams.WRAP_CONTENT));
+//        itemSpecsLinearLayout.setOrientation(LinearLayout.VERTICAL);
+//        itemSpecsLinearLayout.setVisibility(View.GONE);
+//        linearLayout.addView(itemSpecsLinearLayout, linearLayout.indexOfChild(specsLinearLayout) + 1);
+//        costDoc = new ArrayList<>();
+//        costLayout = rootView.findViewById(R.id.cost_linearlayout);
+//        costIcon = rootView.findViewById(R.id.cost_plus);
+//        ImageView itemNameEdit = rootView.findViewById(R.id.itemname_edit);
 
-        LinearLayout proceduresDropdown = rootView.findViewById(R.id.procedures_dropdown);
-        RecyclerView proceduresRecyclerView = rootView.findViewById(R.id.procedures_recycler_view);
-        proceduresRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
-        proceduresRecyclerView.addItemDecoration(new DividerItemDecoration(getContext(),
-                DividerItemDecoration.VERTICAL));
-        ImageView procedureToggleButton = rootView.findViewById(R.id.procedures_toggle_button);
-        proceduresDropdown.setOnClickListener(view -> {
-            if (proceduresRecyclerView.getVisibility() == View.VISIBLE) {
-                proceduresRecyclerView.setVisibility(View.GONE);
-                procedureToggleButton.setImageResource(R.drawable.ic_baseline_plus);
-            } else {
-                proceduresRecyclerView.setVisibility(View.VISIBLE);
-                procedureToggleButton.setImageResource(R.drawable.icon_minimize);
-            }
-        });
+//        LinearLayout proceduresDropdown = rootView.findViewById(R.id.procedures_dropdown);
+//        RecyclerView proceduresRecyclerView = rootView.findViewById(R.id.procedures_recycler_view);
+//        proceduresRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+//        proceduresRecyclerView.addItemDecoration(new DividerItemDecoration(getContext(),
+//                DividerItemDecoration.VERTICAL));
+//        ImageView procedureToggleButton = rootView.findViewById(R.id.procedures_toggle_button);
+//        proceduresDropdown.setOnClickListener(view -> {
+//            if (proceduresRecyclerView.getVisibility() == View.VISIBLE) {
+//                proceduresRecyclerView.setVisibility(View.GONE);
+//                procedureToggleButton.setImageResource(R.drawable.ic_baseline_plus);
+//            } else {
+//                proceduresRecyclerView.setVisibility(View.VISIBLE);
+//                procedureToggleButton.setImageResource(R.drawable.icon_minimize);
+//            }
+//        });
 
 
         deviceViewModel = new ViewModelProvider(this).get(DeviceViewModel.class);
@@ -159,7 +159,7 @@ public class ItemDetailViewFragment extends Fragment {
                     DeviceProduction deviceProduction = deviceModel.getProductions().get(0);
                     expiration.setText(deviceProduction.getExpirationDate());
                     lotNumber.setText(deviceProduction.getLotNumber());
-                    notes.setText(deviceProduction.getNotes());
+//                    notes.setText(deviceProduction.getNotes());
                     physicalLocation.setText(deviceProduction.getPhysicalLocation());
                     itemQuantity = deviceProduction.getStringQuantity();
                     quantity.setText(itemQuantity);
@@ -168,12 +168,12 @@ public class ItemDetailViewFragment extends Fragment {
                     lastUpdate.setText(String.format("%s\n%s", currentDate, currentTime));
                     referenceNumber.setText(deviceProduction.getReferenceNumber());
 
-                    addCostInfo(deviceProduction.getCosts(), rootView);
-
-                    for (Map.Entry<String, Object> specification : deviceModel.getSpecificationList()) {
-                        addItemSpecs(specification.getKey(), specification.getValue().toString(), rootView);
-                    }
-
+//                    addCostInfo(deviceProduction.getCosts(), rootView);
+//
+//                    for (Map.Entry<String, Object> specification : deviceModel.getSpecificationList()) {
+//                        addItemSpecs(specification.getKey(), specification.getValue().toString(), rootView);
+//                    }
+//
                     DeviceProceduresAdapter deviceProceduresAdapter = new DeviceProceduresAdapter(deviceProduction.getProcedures(),deviceProduction.getUniqueDeviceIdentifier());
                     proceduresRecyclerView.setAdapter(deviceProceduresAdapter);
                 }
@@ -188,300 +188,302 @@ public class ItemDetailViewFragment extends Fragment {
                 parent.onBackPressed();
         });
 
-        final boolean[] isSpecsMaximized = {false};
-        specificationLayout.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                if (isSpecsMaximized[0]) {
-                    isSpecsMaximized[0] = false;
-                    itemSpecsLinearLayout.setVisibility(View.GONE);
-                    specificationLayout.setImageResource(R.drawable.ic_baseline_plus);
 
-                } else {
-                    itemSpecsLinearLayout.setVisibility(View.VISIBLE);
-                    specificationLayout.setImageResource(R.drawable.icon_minimize);
-                    isSpecsMaximized[0] = true;
 
-                }
-            }
-        });
+//        final boolean[] isSpecsMaximized = {false};
+//        specificationLayout.setOnClickListener(new View.OnClickListener() {
+//            @Override
+//            public void onClick(View view) {
+//                if (isSpecsMaximized[0]) {
+//                    isSpecsMaximized[0] = false;
+//                    itemSpecsLinearLayout.setVisibility(View.GONE);
+//                    specificationLayout.setImageResource(R.drawable.ic_baseline_plus);
+//
+//                } else {
+//                    itemSpecsLinearLayout.setVisibility(View.VISIBLE);
+//                    specificationLayout.setImageResource(R.drawable.icon_minimize);
+//                    isSpecsMaximized[0] = true;
+//
+//                }
+//            }
+//        });
 
-        itemNameEdit.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                ItemDetailFragment fragment = new ItemDetailFragment();
-                Bundle bundle = new Bundle();
-                bundle.putString("barcode", Objects.requireNonNull(udi.getText()).toString());
-                bundle.putBoolean("editingExisting", true);
-                bundle.putString("di", deviceIdentifier.getText().toString());
-                fragment.setArguments(bundle);
-
-                FragmentManager fragmentManager = requireActivity().getSupportFragmentManager();
-//            //clears other fragments
-                FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-                fragmentTransaction.setCustomAnimations(R.anim.fui_slide_in_right, R.anim.fui_slide_out_left);
-                fragmentTransaction.add(R.id.activity_main, fragment);
-                fragmentTransaction.addToBackStack(null);
-                fragmentTransaction.commit();
-            }
-        });
+//        itemNameEdit.setOnClickListener(new View.OnClickListener() {
+//            @Override
+//            public void onClick(View view) {
+//                ItemDetailFragment fragment = new ItemDetailFragment();
+//                Bundle bundle = new Bundle();
+//                bundle.putString("barcode", Objects.requireNonNull(udi.getText()).toString());
+//                bundle.putBoolean("editingExisting", true);
+//                bundle.putString("di", deviceIdentifier.getText().toString());
+//                fragment.setArguments(bundle);
+//
+//                FragmentManager fragmentManager = requireActivity().getSupportFragmentManager();
+////            //clears other fragments
+//                FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+//                fragmentTransaction.setCustomAnimations(R.anim.fui_slide_in_right, R.anim.fui_slide_out_left);
+//                fragmentTransaction.add(R.id.activity_main, fragment);
+//                fragmentTransaction.addToBackStack(null);
+//                fragmentTransaction.commit();
+//            }
+//        });
 
 
 
         return rootView;
     }
 
-    private void addItemSpecs(String key, String value, View view) {
-
-        LinearLayout eachItemSpecsLayout = new LinearLayout(view.getContext());
-        eachItemSpecsLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT));
-        eachItemSpecsLayout.setOrientation(LinearLayout.HORIZONTAL);
-        eachItemSpecsLayout.setBackgroundColor(Color.WHITE);
-
-        LinearLayout.LayoutParams itemSpecsParams = new LinearLayout.LayoutParams(0,
-                LinearLayout.LayoutParams.MATCH_PARENT);
-        itemSpecsParams.weight = (float) 1.0;
-        itemSpecsParams.setMargins(0, (int) (1 * dp), 0, (int) (1 * dp));
-
-
-        TextView headerKey = new TextView(view.getContext());
-        headerKey.setLayoutParams(itemSpecsParams);
-        headerKey.setPadding((int) (8 * dp), (int) (8 * dp), (int) (8 * dp), (int) (8 * dp));
-        headerKey.setText(key);
-        headerKey.setFocusable(false);
-        headerKey.setTypeface(headerKey.getTypeface(), Typeface.BOLD);
-        headerKey.setTextSize(14);
-        headerKey.setTextColor(Color.BLACK);
-
-
-        LinearLayout.LayoutParams specValueParams = new LinearLayout.LayoutParams(0,
-                LinearLayout.LayoutParams.MATCH_PARENT);
-        specValueParams.weight = (float) 1.0;
-        specValueParams.setMargins(0, (int) (1 * dp), 0, (int) (1 * dp));
-
-        TextView specsValue = new TextView(view.getContext());
-        specsValue.setLayoutParams(specValueParams);
-        specsValue.setPadding((int) (8 * dp), (int) (8 * dp), (int) (8 * dp), (int) (8 * dp));
-        specsValue.setText(value);
-        specsValue.setTextSize(14);
-        specsValue.setTextColor(Color.BLACK);
-
-        eachItemSpecsLayout.addView(headerKey);
-        eachItemSpecsLayout.addView(specsValue);
-
-        itemSpecsLinearLayout.addView(eachItemSpecsLayout);
-    }
-
-
-    private void addCostInfo(List<Cost> costs,View view){
-        if(costs.size() > 0) {
-            int i;
-            final LinearLayout costInfoLayout = new LinearLayout(view.getContext());
-            costInfoLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT));
-            costInfoLayout.setOrientation(LinearLayout.VERTICAL);
-            costInfoLayout.setVisibility(View.GONE);
-
-            for (i = 0; i < costs.size(); i++) {
-
-                final LinearLayout eachEquipmentLayout = new LinearLayout(view.getContext());
-                eachEquipmentLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT));
-                eachEquipmentLayout.setOrientation(LinearLayout.HORIZONTAL);
-                eachEquipmentLayout.setBaselineAligned(false);
-
-                final TextInputLayout costDateHeader = new TextInputLayout(view.getContext());
-                LinearLayout.LayoutParams costHeaderParams = new LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT);
-                costHeaderParams.weight = (float) 1.0;
-                costDateHeader.setLayoutParams(costHeaderParams);
-                TextInputEditText dateKey = new TextInputEditText(costDateHeader.getContext());
-                dateKey.setBackgroundColor(Color.WHITE);
-                dateKey.setText(R.string.purchaseDate_lbl);
-                dateKey.setTypeface(dateKey.getTypeface(), Typeface.BOLD);
-                dateKey.setFocusable(false);
-                costDateHeader.addView(dateKey);
+//    private void addItemSpecs(String key, String value, View view) {
+//
+//        LinearLayout eachItemSpecsLayout = new LinearLayout(view.getContext());
+//        eachItemSpecsLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+//                ViewGroup.LayoutParams.WRAP_CONTENT));
+//        eachItemSpecsLayout.setOrientation(LinearLayout.HORIZONTAL);
+//        eachItemSpecsLayout.setBackgroundColor(Color.WHITE);
+//
+//        LinearLayout.LayoutParams itemSpecsParams = new LinearLayout.LayoutParams(0,
+//                LinearLayout.LayoutParams.MATCH_PARENT);
+//        itemSpecsParams.weight = (float) 1.0;
+//        itemSpecsParams.setMargins(0, (int) (1 * dp), 0, (int) (1 * dp));
+//
+//
+//        TextView headerKey = new TextView(view.getContext());
+//        headerKey.setLayoutParams(itemSpecsParams);
+//        headerKey.setPadding((int) (8 * dp), (int) (8 * dp), (int) (8 * dp), (int) (8 * dp));
+//        headerKey.setText(key);
+//        headerKey.setFocusable(false);
+//        headerKey.setTypeface(headerKey.getTypeface(), Typeface.BOLD);
+//        headerKey.setTextSize(14);
+//        headerKey.setTextColor(Color.BLACK);
+//
+//
+//        LinearLayout.LayoutParams specValueParams = new LinearLayout.LayoutParams(0,
+//                LinearLayout.LayoutParams.MATCH_PARENT);
+//        specValueParams.weight = (float) 1.0;
+//        specValueParams.setMargins(0, (int) (1 * dp), 0, (int) (1 * dp));
+//
+//        TextView specsValue = new TextView(view.getContext());
+//        specsValue.setLayoutParams(specValueParams);
+//        specsValue.setPadding((int) (8 * dp), (int) (8 * dp), (int) (8 * dp), (int) (8 * dp));
+//        specsValue.setText(value);
+//        specsValue.setTextSize(14);
+//        specsValue.setTextColor(Color.BLACK);
+//
+//        eachItemSpecsLayout.addView(headerKey);
+//        eachItemSpecsLayout.addView(specsValue);
+//
+//        itemSpecsLinearLayout.addView(eachItemSpecsLayout);
+//    }
 
 
-                final TextInputLayout costDateText = new TextInputLayout(view.getContext());
-                LinearLayout.LayoutParams costParams = new LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT);
-                costParams.weight = (float) 1.0;
-                costDateText.setLayoutParams(costParams);
-                TextInputEditText dateText = new TextInputEditText(costDateText.getContext());
-                dateText.setText(costs.get(i).getCostDate());
-                dateText.setBackgroundColor(Color.WHITE);
-                dateText.setFocusable(false);
-                costDateText.addView(dateText);
-                costDateText.setEndIconMode(TextInputLayout.END_ICON_CUSTOM);
-                costDateText.setEndIconDrawable(R.drawable.ic_baseline_plus);
-                costDateText.setEndIconTintList(ColorStateList.valueOf(getResources().
-                        getColor(R.color.colorPrimary, requireActivity().getTheme())));
-
-                eachEquipmentLayout.addView(costDateHeader);
-                eachEquipmentLayout.addView(costDateText);
-                costInfoLayout.addView(eachEquipmentLayout);
-
-
-                final LinearLayout costInfoDetails = new LinearLayout(view.getContext());
-                costInfoDetails.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT));
-                costInfoDetails.setOrientation(LinearLayout.VERTICAL);
-                costInfoDetails.setVisibility(View.GONE);
-
-                final LinearLayout packagePriceLinearLayout = new LinearLayout(view.getContext());
-                packagePriceLinearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT));
-                packagePriceLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
-                packagePriceLinearLayout.setBaselineAligned(false);
-
-                final TextInputLayout packagePriceHeader = new TextInputLayout(view.getContext());
-                LinearLayout.LayoutParams packageHeaderParams = new LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT);
-                packageHeaderParams.weight = (float) 1.0;
-                packagePriceHeader.setLayoutParams(packageHeaderParams);
-                TextInputEditText packageKey = new TextInputEditText(packagePriceHeader.getContext());
-                packageKey.setBackgroundColor(Color.WHITE);
-                packageKey.setText(R.string.packageCost_lbl);
-                packageKey.setTypeface(packageKey.getTypeface(), Typeface.BOLD);
-                packageKey.setFocusable(false);
-                packagePriceHeader.addView(packageKey);
-
-                final TextInputLayout packagePriceText = new TextInputLayout(view.getContext());
-                LinearLayout.LayoutParams packageParams = new LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT);
-                packageParams.weight = (float) 1.0;
-                packagePriceText.setLayoutParams(packageParams);
-                TextInputEditText packagePriceEditText = new TextInputEditText(packagePriceText.getContext());
-                packagePriceEditText.setText(String.format("$ %s", costs.get(i).getPackagePrice()));
-                packagePriceEditText.setBackgroundColor(Color.WHITE);
-                packagePriceEditText.setFocusable(false);
-                packagePriceText.addView(packagePriceEditText);
-
-                packagePriceLinearLayout.addView(packagePriceHeader);
-                packagePriceLinearLayout.addView(packagePriceText);
-
-                final LinearLayout numberAddedLinearLayout = new LinearLayout(view.getContext());
-                numberAddedLinearLayout .setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT));
-                numberAddedLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
-                numberAddedLinearLayout.setBaselineAligned(false);
-
-
-                final TextInputLayout numberAddedHeader = new TextInputLayout(view.getContext());
-                LinearLayout.LayoutParams numberAddedHeaderParams = new LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT);
-                numberAddedHeaderParams.weight = (float) 1.0;
-                numberAddedHeader.setLayoutParams(numberAddedHeaderParams);
-                TextInputEditText numberAddedKey = new TextInputEditText(numberAddedHeader.getContext());
-                numberAddedKey.setBackgroundColor(Color.WHITE);
-                numberAddedKey.setText(R.string.units_lbl);
-                numberAddedKey.setTypeface(numberAddedKey.getTypeface(), Typeface.BOLD);
-                numberAddedKey.setFocusable(false);
-                numberAddedHeader.addView(numberAddedKey);
-
-                final TextInputLayout numberAddedText = new TextInputLayout(view.getContext());
-                LinearLayout.LayoutParams numberAddedParams = new LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT);
-                numberAddedParams.weight = (float) 1.0;
-                numberAddedText.setLayoutParams(numberAddedParams);
-                TextInputEditText numberAddedEditText = new TextInputEditText(numberAddedText.getContext());
-                numberAddedEditText.setText(Integer.toString(costs.get(i).getNumberAdded()));
-                numberAddedEditText.setBackgroundColor(Color.WHITE);
-                numberAddedEditText.setFocusable(false);
-                numberAddedText.addView(numberAddedEditText);
-
-                numberAddedLinearLayout.addView(numberAddedHeader);
-                numberAddedLinearLayout.addView(numberAddedText);
-
-                final LinearLayout unitCostLinearLayout = new LinearLayout(view.getContext());
-                unitCostLinearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT));
-                unitCostLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
-                unitCostLinearLayout.setBaselineAligned(false);
-
-
-                final TextInputLayout unitCostHeader = new TextInputLayout(view.getContext());
-                LinearLayout.LayoutParams unitCostParams = new LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT);
-                unitCostParams.weight = (float) 1.0;
-                unitCostHeader.setLayoutParams(unitCostParams);
-                TextInputEditText unitCostKey = new TextInputEditText(unitCostHeader.getContext());
-                unitCostKey.setBackgroundColor(Color.WHITE);
-                unitCostKey.setText(R.string.costUnit_lbl);
-                unitCostKey.setTypeface(dateKey.getTypeface(), Typeface.BOLD);
-                unitCostKey.setFocusable(false);
-                unitCostHeader.addView(unitCostKey);
-
-                final TextInputLayout unitCostText = new TextInputLayout(view.getContext());
-                LinearLayout.LayoutParams unitCostTextParams = new LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT);
-                unitCostTextParams.weight = (float) 1.0;
-                unitCostText.setLayoutParams(unitCostTextParams);
-                TextInputEditText unitCostEditText = new TextInputEditText(unitCostText.getContext());
-                unitCostEditText.setText(String.format("$ %s", costs.get(i).getUnitPrice()));
-                unitCostEditText.setBackgroundColor(Color.WHITE);
-                unitCostEditText.setFocusable(false);
-                unitCostText.addView(unitCostEditText);
-
-                unitCostLinearLayout.addView(unitCostHeader);
-                unitCostLinearLayout.addView(unitCostText);
-
-                costInfoDetails.addView(packagePriceLinearLayout);
-                costInfoDetails.addView(numberAddedLinearLayout);
-                costInfoDetails.addView(unitCostLinearLayout);
-
-                costInfoLayout.addView(costInfoDetails);
-
-
-
-                final boolean[] isDetailMaximized = {false};
-                costDateText.setEndIconOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        if(isDetailMaximized[0]){
-                            costInfoDetails.setVisibility(View.GONE);
-                            isDetailMaximized[0] = false;
-                            costDateText.setEndIconDrawable(R.drawable.ic_baseline_plus);
-
-                        }else{
-                            costInfoDetails.setVisibility(View.VISIBLE);
-                            isDetailMaximized[0] = true;
-                            costDateText.setEndIconDrawable(R.drawable.icon_minimize);
-                        }
-                    }
-                });
-
-            }
-            linearLayout.addView(costInfoLayout, linearLayout.indexOfChild(costLayout) + 1);
-
-
-            final boolean[] isMaximized = {false};
-            costIcon.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    if(isMaximized[0]){
-                        costInfoLayout.setVisibility(View.GONE);
-                        isMaximized[0] = false;
-                        costIcon.setImageResource(R.drawable.ic_baseline_plus);
-
-                    }else{
-                        costInfoLayout.setVisibility(View.VISIBLE);
-                        isMaximized[0] = true;
-                        costIcon.setImageResource(R.drawable.icon_minimize);
-                    }
-                }
-            });
-        }
-    }
+//    private void addCostInfo(List<Cost> costs,View view){
+//        if(costs.size() > 0) {
+//            int i;
+//            final LinearLayout costInfoLayout = new LinearLayout(view.getContext());
+//            costInfoLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+//                    ViewGroup.LayoutParams.WRAP_CONTENT));
+//            costInfoLayout.setOrientation(LinearLayout.VERTICAL);
+//            costInfoLayout.setVisibility(View.GONE);
+//
+//            for (i = 0; i < costs.size(); i++) {
+//
+//                final LinearLayout eachEquipmentLayout = new LinearLayout(view.getContext());
+//                eachEquipmentLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+//                        ViewGroup.LayoutParams.WRAP_CONTENT));
+//                eachEquipmentLayout.setOrientation(LinearLayout.HORIZONTAL);
+//                eachEquipmentLayout.setBaselineAligned(false);
+//
+//                final TextInputLayout costDateHeader = new TextInputLayout(view.getContext());
+//                LinearLayout.LayoutParams costHeaderParams = new LinearLayout.LayoutParams(
+//                        LinearLayout.LayoutParams.MATCH_PARENT,
+//                        LinearLayout.LayoutParams.WRAP_CONTENT);
+//                costHeaderParams.weight = (float) 1.0;
+//                costDateHeader.setLayoutParams(costHeaderParams);
+//                TextInputEditText dateKey = new TextInputEditText(costDateHeader.getContext());
+//                dateKey.setBackgroundColor(Color.WHITE);
+//                dateKey.setText(R.string.purchaseDate_lbl);
+//                dateKey.setTypeface(dateKey.getTypeface(), Typeface.BOLD);
+//                dateKey.setFocusable(false);
+//                costDateHeader.addView(dateKey);
+//
+//
+//                final TextInputLayout costDateText = new TextInputLayout(view.getContext());
+//                LinearLayout.LayoutParams costParams = new LinearLayout.LayoutParams(
+//                        LinearLayout.LayoutParams.MATCH_PARENT,
+//                        LinearLayout.LayoutParams.WRAP_CONTENT);
+//                costParams.weight = (float) 1.0;
+//                costDateText.setLayoutParams(costParams);
+//                TextInputEditText dateText = new TextInputEditText(costDateText.getContext());
+//                dateText.setText(costs.get(i).getCostDate());
+//                dateText.setBackgroundColor(Color.WHITE);
+//                dateText.setFocusable(false);
+//                costDateText.addView(dateText);
+//                costDateText.setEndIconMode(TextInputLayout.END_ICON_CUSTOM);
+//                costDateText.setEndIconDrawable(R.drawable.ic_baseline_plus);
+//                costDateText.setEndIconTintList(ColorStateList.valueOf(getResources().
+//                        getColor(R.color.colorPrimary, requireActivity().getTheme())));
+//
+//                eachEquipmentLayout.addView(costDateHeader);
+//                eachEquipmentLayout.addView(costDateText);
+//                costInfoLayout.addView(eachEquipmentLayout);
+//
+//
+//                final LinearLayout costInfoDetails = new LinearLayout(view.getContext());
+//                costInfoDetails.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+//                        ViewGroup.LayoutParams.WRAP_CONTENT));
+//                costInfoDetails.setOrientation(LinearLayout.VERTICAL);
+//                costInfoDetails.setVisibility(View.GONE);
+//
+//                final LinearLayout packagePriceLinearLayout = new LinearLayout(view.getContext());
+//                packagePriceLinearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+//                        ViewGroup.LayoutParams.WRAP_CONTENT));
+//                packagePriceLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
+//                packagePriceLinearLayout.setBaselineAligned(false);
+//
+//                final TextInputLayout packagePriceHeader = new TextInputLayout(view.getContext());
+//                LinearLayout.LayoutParams packageHeaderParams = new LinearLayout.LayoutParams(
+//                        LinearLayout.LayoutParams.MATCH_PARENT,
+//                        LinearLayout.LayoutParams.WRAP_CONTENT);
+//                packageHeaderParams.weight = (float) 1.0;
+//                packagePriceHeader.setLayoutParams(packageHeaderParams);
+//                TextInputEditText packageKey = new TextInputEditText(packagePriceHeader.getContext());
+//                packageKey.setBackgroundColor(Color.WHITE);
+//                packageKey.setText(R.string.packageCost_lbl);
+//                packageKey.setTypeface(packageKey.getTypeface(), Typeface.BOLD);
+//                packageKey.setFocusable(false);
+//                packagePriceHeader.addView(packageKey);
+//
+//                final TextInputLayout packagePriceText = new TextInputLayout(view.getContext());
+//                LinearLayout.LayoutParams packageParams = new LinearLayout.LayoutParams(
+//                        LinearLayout.LayoutParams.MATCH_PARENT,
+//                        LinearLayout.LayoutParams.WRAP_CONTENT);
+//                packageParams.weight = (float) 1.0;
+//                packagePriceText.setLayoutParams(packageParams);
+//                TextInputEditText packagePriceEditText = new TextInputEditText(packagePriceText.getContext());
+//                packagePriceEditText.setText(String.format("$ %s", costs.get(i).getPackagePrice()));
+//                packagePriceEditText.setBackgroundColor(Color.WHITE);
+//                packagePriceEditText.setFocusable(false);
+//                packagePriceText.addView(packagePriceEditText);
+//
+//                packagePriceLinearLayout.addView(packagePriceHeader);
+//                packagePriceLinearLayout.addView(packagePriceText);
+//
+//                final LinearLayout numberAddedLinearLayout = new LinearLayout(view.getContext());
+//                numberAddedLinearLayout .setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+//                        ViewGroup.LayoutParams.WRAP_CONTENT));
+//                numberAddedLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
+//                numberAddedLinearLayout.setBaselineAligned(false);
+//
+//
+//                final TextInputLayout numberAddedHeader = new TextInputLayout(view.getContext());
+//                LinearLayout.LayoutParams numberAddedHeaderParams = new LinearLayout.LayoutParams(
+//                        LinearLayout.LayoutParams.MATCH_PARENT,
+//                        LinearLayout.LayoutParams.WRAP_CONTENT);
+//                numberAddedHeaderParams.weight = (float) 1.0;
+//                numberAddedHeader.setLayoutParams(numberAddedHeaderParams);
+//                TextInputEditText numberAddedKey = new TextInputEditText(numberAddedHeader.getContext());
+//                numberAddedKey.setBackgroundColor(Color.WHITE);
+//                numberAddedKey.setText(R.string.units_lbl);
+//                numberAddedKey.setTypeface(numberAddedKey.getTypeface(), Typeface.BOLD);
+//                numberAddedKey.setFocusable(false);
+//                numberAddedHeader.addView(numberAddedKey);
+//
+//                final TextInputLayout numberAddedText = new TextInputLayout(view.getContext());
+//                LinearLayout.LayoutParams numberAddedParams = new LinearLayout.LayoutParams(
+//                        LinearLayout.LayoutParams.MATCH_PARENT,
+//                        LinearLayout.LayoutParams.WRAP_CONTENT);
+//                numberAddedParams.weight = (float) 1.0;
+//                numberAddedText.setLayoutParams(numberAddedParams);
+//                TextInputEditText numberAddedEditText = new TextInputEditText(numberAddedText.getContext());
+//                numberAddedEditText.setText(Integer.toString(costs.get(i).getNumberAdded()));
+//                numberAddedEditText.setBackgroundColor(Color.WHITE);
+//                numberAddedEditText.setFocusable(false);
+//                numberAddedText.addView(numberAddedEditText);
+//
+//                numberAddedLinearLayout.addView(numberAddedHeader);
+//                numberAddedLinearLayout.addView(numberAddedText);
+//
+//                final LinearLayout unitCostLinearLayout = new LinearLayout(view.getContext());
+//                unitCostLinearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+//                        ViewGroup.LayoutParams.WRAP_CONTENT));
+//                unitCostLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
+//                unitCostLinearLayout.setBaselineAligned(false);
+//
+//
+//                final TextInputLayout unitCostHeader = new TextInputLayout(view.getContext());
+//                LinearLayout.LayoutParams unitCostParams = new LinearLayout.LayoutParams(
+//                        LinearLayout.LayoutParams.MATCH_PARENT,
+//                        LinearLayout.LayoutParams.WRAP_CONTENT);
+//                unitCostParams.weight = (float) 1.0;
+//                unitCostHeader.setLayoutParams(unitCostParams);
+//                TextInputEditText unitCostKey = new TextInputEditText(unitCostHeader.getContext());
+//                unitCostKey.setBackgroundColor(Color.WHITE);
+//                unitCostKey.setText(R.string.costUnit_lbl);
+//                unitCostKey.setTypeface(dateKey.getTypeface(), Typeface.BOLD);
+//                unitCostKey.setFocusable(false);
+//                unitCostHeader.addView(unitCostKey);
+//
+//                final TextInputLayout unitCostText = new TextInputLayout(view.getContext());
+//                LinearLayout.LayoutParams unitCostTextParams = new LinearLayout.LayoutParams(
+//                        LinearLayout.LayoutParams.MATCH_PARENT,
+//                        LinearLayout.LayoutParams.WRAP_CONTENT);
+//                unitCostTextParams.weight = (float) 1.0;
+//                unitCostText.setLayoutParams(unitCostTextParams);
+//                TextInputEditText unitCostEditText = new TextInputEditText(unitCostText.getContext());
+//                unitCostEditText.setText(String.format("$ %s", costs.get(i).getUnitPrice()));
+//                unitCostEditText.setBackgroundColor(Color.WHITE);
+//                unitCostEditText.setFocusable(false);
+//                unitCostText.addView(unitCostEditText);
+//
+//                unitCostLinearLayout.addView(unitCostHeader);
+//                unitCostLinearLayout.addView(unitCostText);
+//
+//                costInfoDetails.addView(packagePriceLinearLayout);
+//                costInfoDetails.addView(numberAddedLinearLayout);
+//                costInfoDetails.addView(unitCostLinearLayout);
+//
+//                costInfoLayout.addView(costInfoDetails);
+//
+//
+//
+//                final boolean[] isDetailMaximized = {false};
+//                costDateText.setEndIconOnClickListener(new View.OnClickListener() {
+//                    @Override
+//                    public void onClick(View view) {
+//                        if(isDetailMaximized[0]){
+//                            costInfoDetails.setVisibility(View.GONE);
+//                            isDetailMaximized[0] = false;
+//                            costDateText.setEndIconDrawable(R.drawable.ic_baseline_plus);
+//
+//                        }else{
+//                            costInfoDetails.setVisibility(View.VISIBLE);
+//                            isDetailMaximized[0] = true;
+//                            costDateText.setEndIconDrawable(R.drawable.icon_minimize);
+//                        }
+//                    }
+//                });
+//
+//            }
+//            linearLayout.addView(costInfoLayout, linearLayout.indexOfChild(costLayout) + 1);
+//
+//
+//            final boolean[] isMaximized = {false};
+//            costIcon.setOnClickListener(new View.OnClickListener() {
+//                @Override
+//                public void onClick(View view) {
+//                    if(isMaximized[0]){
+//                        costInfoLayout.setVisibility(View.GONE);
+//                        isMaximized[0] = false;
+//                        costIcon.setImageResource(R.drawable.ic_baseline_plus);
+//
+//                    }else{
+//                        costInfoLayout.setVisibility(View.VISIBLE);
+//                        isMaximized[0] = true;
+//                        costIcon.setImageResource(R.drawable.icon_minimize);
+//                    }
+//                }
+//            });
+//        }
+//    }
 
 }

--- a/app/src/main/java/org/getcarebase/carebase/views/DetailLabeledTextView.java
+++ b/app/src/main/java/org/getcarebase/carebase/views/DetailLabeledTextView.java
@@ -29,6 +29,10 @@ public class DetailLabeledTextView extends LinearLayout {
         labelTextView.setText(label);
     }
 
+    public CharSequence getTextValue() {
+        return valueTextView.getText();
+    }
+
     public void setTextValue(CharSequence value) {
         valueTextView.setText(value);
         invalidate();

--- a/app/src/main/res/drawable/icon_edit.xml
+++ b/app/src/main/res/drawable/icon_edit.xml
@@ -8,6 +8,6 @@
   <path
       android:pathData="M0 0h24v24H0z" />
   <path
-      android:fillColor="#000000"
+      android:fillColor="@android:color/white"
       android:pathData="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c0.39-0.39 0.39 -1.02 0-1.41l-2.34-2.34c-0.39-0.39-1.02-0.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
 </vector>

--- a/app/src/main/res/layout/fragment_viewonlyitemdetail.xml
+++ b/app/src/main/res/layout/fragment_viewonlyitemdetail.xml
@@ -1,609 +1,209 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/colorBackground"
-    android:orientation="vertical"
-    android:theme="@style/AppTheme">
+    android:elevation="5dp"
+    android:background="@android:color/white"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/topAppBar"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        app:navigationIcon="@drawable/icon_back"
-        app:title="Equipment Specifications"
-        style="@style/Widget.MaterialComponents.Toolbar.Primary" />
-
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/scrollView"
-        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:scrollbars="vertical"
-        app:layout_constraintTop_toTopOf="parent">
+        app:navigationIcon="@drawable/icon_back"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="Equipment View"
 
-        <LinearLayout
-            android:id="@+id/itemdetailviewonly_linearlayout"
+        style="@style/Widget.Carebase.ToolBar.Gradient"
+        app:menu="@menu/toolbar_edit" />
+
+    <LinearLayout
+        android:id="@+id/detail_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:padding="16dp"
+        android:background="#FAFAFA"
+        android:elevation="2dp"
+        app:layout_constraintTop_toBottomOf="@id/topAppBar"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/itemname_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            tools:text="Angioplasty and Stint Insertion"
+            android:textSize="8pt"/>
+
+        <View
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginHorizontal="12dp"
-            android:layout_marginBottom="44dp"
-            android:orientation="vertical">
+            android:layout_height="0.8dp"
+            android:layout_marginVertical="12dp"
+            android:background="@color/colorLightGrey"/>
 
-            <LinearLayout
-                android:layout_width="match_parent"
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Details"
+            android:textSize="5pt"
+            android:textColor="@color/colorPrimary"
+            android:textStyle="bold"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"/>
+
+        <GridLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp"
+            android:columnCount="2"
+            android:rowCount="5"
+            android:useDefaultMargins="true">
+
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/di_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:layout_marginBottom="1dp"
-                android:background="@color/colorPrimary">
+                android:layout_columnWeight="1"
+                app:label_text="Device ID" />
 
-                <TextView
-                    android:id="@+id/itemname_text"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="5"
-                    android:padding="16dp"
-                    android:textAlignment="textStart"
-                    android:textColor="#ffffff"
-                    android:textSize="20sp" />
-
-                <ImageView
-                    android:id="@+id/itemname_edit"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="16dp"
-                    android:src="@drawable/icon_edit"
-                    android:tint="@android:color/white" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/quantity_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Units" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/barcode_udi_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/barcode_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/physicallocation_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Location" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/device_identifier_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/di_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/expiration_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Expiration" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/quantity_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/quantity_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/usage_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Use" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/expiration_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/expiration_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/unitcost_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Cost / Unit" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/hospital_name_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/site_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/company_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Manufacture" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/physical_location_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/physicallocation_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/lotnumber_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Lot" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/type_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/type_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/referencenumber_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Reference Number" />
+        </GridLayout>
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/usage_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0.8dp"
+            android:layout_marginBottom="12dp"
+            android:background="@color/colorLightGrey"/>
 
-                <TextView
-                    android:id="@+id/usage_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
+        <TextView
+            android:paddingVertical="8dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Specifications"
+            android:textSize="5pt"
+            android:textColor="@color/colorPrimary"
+            android:textStyle="bold"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"/>
 
-            <LinearLayout
-                android:layout_width="match_parent"
+        <GridLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp"
+            android:columnCount="2"
+            android:rowCount="2"
+            android:useDefaultMargins="true">
+
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/type_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Type" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/medical_specialty_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/medicalspecialty_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/medicalspecialty_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Specialty" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/device_description_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/devicedescription_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/devicedescription_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Size" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/reference_number_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/referencenumber_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.getcarebase.carebase.views.DetailLabeledTextView
+                android:id="@+id/length_edittext"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+                android:layout_columnWeight="1"
+                app:label_text="Length" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/lot_number_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
+        </GridLayout>
 
-                <TextView
-                    android:id="@+id/lotnumber_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0.8dp"
+            android:layout_marginVertical="12dp"
+            android:background="@color/colorLightGrey"/>
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
+        <GridLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp"
+            android:columnCount="2"
+            android:rowCount="5"
+            android:useDefaultMargins="true">
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/manufacturer_company_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/company_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/last_update_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/lasteupdate_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="1dp"
-                android:background="@android:color/white"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:focusable="false"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/notes_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/notes_edittext"
-                    style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/cost_linearlayout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="5"
-                    android:padding="8dp"
-                    android:text="@string/cost_lbl"
-                    android:textColor="@android:color/black"
-                    android:textSize="20sp"
-                    android:textStyle="bold" />
-
-                <ImageView
-                    android:id="@+id/cost_plus"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:src="@drawable/ic_baseline_plus"
-                    android:tint="@color/colorPrimary" />
-            </LinearLayout>
-
-
-            <LinearLayout
-                android:id="@+id/specs_linearlayout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="5"
-                    android:gravity="center_vertical"
-                    android:padding="8dp"
-                    android:text="@string/specification_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="20sp"
-                    android:textStyle="bold" />
-
-                <ImageView
-                    android:id="@+id/specifications_plus"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:src="@drawable/ic_baseline_plus"
-                    android:tint="@color/colorPrimary" />
-
-
-            </LinearLayout>
-
-
-            <LinearLayout
-                android:id="@+id/procedures_dropdown"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="5"
-                    android:padding="8dp"
-                    android:text="@string/usage_label"
-                    android:textColor="@android:color/black"
-                    android:textSize="20sp"
-                    android:textStyle="bold" />
-
-                <ImageView
-                    android:id="@+id/procedures_toggle_button"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    android:src="@drawable/ic_baseline_plus"
-                    android:tint="@color/colorPrimary" />
-            </LinearLayout>
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/procedures_recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:nestedScrollingEnabled="true"
-                android:orientation="vertical"
-                android:scrollbars="vertical"
-                android:visibility="gone">
-
-            </androidx.recyclerview.widget.RecyclerView>
-        </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
-</LinearLayout>
+        <org.getcarebase.carebase.views.DetailLabeledTextView
+            android:id="@+id/lasteupdate_edittext"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_columnWeight="1"
+            app:label_text="Updated" />
+        </GridLayout>
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_viewonlyitemdetail.xml
+++ b/app/src/main/res/layout/fragment_viewonlyitemdetail.xml
@@ -14,21 +14,25 @@
         app:navigationIcon="@drawable/icon_back"
         app:layout_constraintTop_toTopOf="parent"
         app:title="Equipment View"
-
         style="@style/Widget.Carebase.ToolBar.Gradient"
         app:menu="@menu/toolbar_edit" />
 
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/topAppBar"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
+
     <LinearLayout
         android:id="@+id/detail_layout"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
         android:padding="16dp"
         android:background="#FAFAFA"
         android:elevation="2dp"
-        app:layout_constraintTop_toBottomOf="@id/topAppBar"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
         android:orientation="vertical">
 
         <TextView
@@ -39,6 +43,16 @@
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
             tools:text="Angioplasty and Stint Insertion"
             android:textSize="8pt"/>
+
+        <TextView
+            android:id="@+id/udi_edittext"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="5pt"
+            android:textColor="@color/colorGrey"
+            android:textStyle="bold"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+            tools:text="(01)997542937(17)201508(10)88325"/>
 
         <View
             android:layout_width="match_parent"
@@ -76,7 +90,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_columnWeight="1"
-                app:label_text="Units" />
+                app:label_text="Quantity" />
 
             <org.getcarebase.carebase.views.DetailLabeledTextView
                 android:id="@+id/physicallocation_edittext"
@@ -167,21 +181,15 @@
                 android:layout_columnWeight="1"
                 app:label_text="Specialty" />
 
-            <org.getcarebase.carebase.views.DetailLabeledTextView
-                android:id="@+id/devicedescription_edittext"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                app:label_text="Size" />
-
-            <org.getcarebase.carebase.views.DetailLabeledTextView
-                android:id="@+id/length_edittext"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                app:label_text="Length" />
-
         </GridLayout>
+
+
+        <org.getcarebase.carebase.views.DetailLabeledTextView
+            android:id="@+id/devicedescription_edittext"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            app:label_text="Description" />
 
         <View
             android:layout_width="match_parent"
@@ -206,4 +214,5 @@
             app:label_text="Updated" />
         </GridLayout>
     </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/toolbar_edit.xml
+++ b/app/src/main/res/menu/toolbar_edit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/itemname_edit"
+        android:icon="@drawable/icon_edit"
+        android:iconTint="@android:color/white"
+        android:title="Edit"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/menu/toolbar_edit.xml
+++ b/app/src/main/res/menu/toolbar_edit.xml
@@ -5,7 +5,6 @@
     <item
         android:id="@+id/itemname_edit"
         android:icon="@drawable/icon_edit"
-        android:iconTint="@android:color/white"
         android:title="Edit"
         app:showAsAction="ifRoom" />
 


### PR DESCRIPTION
Closes #79 
This pull request repositioned and updated ItemDetailView fields to match the following design.

![](https://user-images.githubusercontent.com/15002610/106657329-e1d90600-6569-11eb-8a57-8796d57f66f0.png)

**View After (see issue #79 for the view before)**
![ItemDetailView1](https://user-images.githubusercontent.com/55464213/107095787-73997b00-67d7-11eb-8830-2bf56b085f64.png)
![ItemDetailView2](https://user-images.githubusercontent.com/55464213/107095802-77c59880-67d7-11eb-8280-8d40ab8adf25.png)
